### PR TITLE
Allow missing searchParams and params

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"svelte": "^5.0.0",
-		"@sveltejs/kit": "^2.0.0"
+		"@sveltejs/kit": "^2.0.0",
+		"svelte": "^5.0.0"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^6.0.1",
@@ -43,6 +43,7 @@
 		"eslint": "^9.32.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.11.0",
+		"jsdom": "^26.1.0",
 		"prettier": "^3.6.2",
 		"prettier-plugin-svelte": "^3.4.0",
 		"publint": "^0.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skroutes",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && pnpm run package",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^3.11.0
         version: 3.11.0(eslint@9.32.0)(svelte@5.37.3)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -77,7 +80,7 @@ importers:
         version: 7.0.6(@types/node@24.1.0)(yaml@2.4.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.1.0)(yaml@2.4.2)
+        version: 3.2.4(@types/node@24.1.0)(jsdom@26.1.0)(yaml@2.4.2)
       zod:
         specifier: ^4.0.14
         version: 4.0.14
@@ -87,6 +90,37 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@csstools/color-helpers@5.0.2':
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.0.10':
+    resolution: {integrity: sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
@@ -600,6 +634,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -686,6 +724,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -694,6 +740,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
@@ -711,6 +760,10 @@ packages:
 
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -866,6 +919,22 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -894,6 +963,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -906,6 +978,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -953,6 +1034,9 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -993,6 +1077,9 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  nwsapi@2.2.21:
+    resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1011,6 +1098,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
@@ -1117,6 +1207,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1128,6 +1221,13 @@ packages:
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -1200,6 +1300,9 @@ packages:
     resolution: {integrity: sha512-7t/ejshehHd+95z3Z7ebS7wsqHDQxi/8nBTuTRwpMgNegfRBfuitCSKTUDKIBOExqfT2+DhQ2VLG8Xn+cBXoaQ==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1222,6 +1325,13 @@ packages:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1229,6 +1339,14 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1338,6 +1456,26 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1351,6 +1489,25 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -1377,6 +1534,34 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@csstools/color-helpers@5.0.2': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
@@ -1828,6 +2013,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1905,9 +2092,21 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   dedent-js@1.0.1: {}
 
@@ -1918,6 +2117,8 @@ snapshots:
   deepmerge@4.3.1: {}
 
   devalue@5.1.1: {}
+
+  entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2114,6 +2315,28 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2133,6 +2356,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2144,6 +2369,33 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.21
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   json-buffer@3.0.1: {}
 
@@ -2182,6 +2434,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
@@ -2216,6 +2470,8 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  nwsapi@2.2.21: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2238,6 +2494,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   pascal-case@3.1.2:
     dependencies:
@@ -2336,6 +2596,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -2348,6 +2610,12 @@ snapshots:
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   semver@7.7.2: {}
 
@@ -2430,6 +2698,8 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  symbol-tree@3.2.4: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2445,11 +2715,25 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
@@ -2509,7 +2793,7 @@ snapshots:
     optionalDependencies:
       vite: 7.0.6(@types/node@24.1.0)(yaml@2.4.2)
 
-  vitest@3.2.4(@types/node@24.1.0)(yaml@2.4.2):
+  vitest@3.2.4(@types/node@24.1.0)(jsdom@26.1.0)(yaml@2.4.2):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -2536,6 +2820,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.1.0
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -2550,6 +2835,23 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2560,6 +2862,12 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml@1.10.2: {}
 

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -5,11 +5,26 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 // Import schema definitions from client-side page files only
 import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';
+import { _routeConfig as routeConfig1 } from '../../../src/routes/test-no-validation/+page';
+import { _routeConfig as routeConfig2 } from '../../../src/routes/test-partial/[id]/+page';
+import { _routeConfig as routeConfig3 } from '../../../src/routes/test-search-only/+page';
 
 export const clientRouteConfig = {
   '/[id]': {
           paramsValidation: routeConfig0.paramsValidation,
           searchParamsValidation: routeConfig0.searchParamsValidation,
+        },
+  '/test-no-validation': {
+          paramsValidation: undefined,
+          searchParamsValidation: undefined,
+        },
+  '/test-partial/[id]': {
+          paramsValidation: routeConfig2.paramsValidation,
+          searchParamsValidation: undefined,
+        },
+  '/test-search-only': {
+          paramsValidation: undefined,
+          searchParamsValidation: routeConfig3.searchParamsValidation,
         },
   '/': {
           paramsValidation: undefined,
@@ -188,11 +203,14 @@ export const clientRouteConfig = {
 } as const;
 
 // Export route keys for type checking
-export type RouteKeys = '/[id]' | '/' | '/api/users/[id]' | '/error' | '/optional/[[slug]]' | '/products/[id]' | '/server/[id]' | '/store/[id]' | '/type-test/[id]' | '/users/[id]';
+export type RouteKeys = '/[id]' | '/test-no-validation' | '/test-partial/[id]' | '/test-search-only' | '/' | '/api/users/[id]' | '/error' | '/optional/[[slug]]' | '/products/[id]' | '/server/[id]' | '/store/[id]' | '/type-test/[id]' | '/users/[id]';
 
 // Export type mapping for schema inference
 export type RouteTypeMap = {
   '/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig0.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig0.searchParamsValidation> };
+  '/test-no-validation': { params: Record<string, string>; searchParams: Record<string, unknown> };
+  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: Record<string, unknown> };
+  '/test-search-only': { params: Record<string, string>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
   '/': { params: Record<string, string>; searchParams: Record<string, unknown> };
   '/api/users/[id]': { params: { id: string }; searchParams: Record<string, unknown> };
   '/error': { params: Record<string, string>; searchParams: Record<string, unknown> };

--- a/src/lib/.generated/skroutes-server-config.ts
+++ b/src/lib/.generated/skroutes-server-config.ts
@@ -8,8 +8,11 @@ import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';
 import { _routeConfig as routeConfig1 } from '../../../src/routes/api/users/[id]/+server';
 import { _routeConfig as routeConfig2 } from '../../../src/routes/products/[id]/+page.server';
 import { _routeConfig as routeConfig3 } from '../../../src/routes/server/[id]/+page.server';
-import { _routeConfig as routeConfig4 } from '../../../src/routes/type-test/[id]/+page.server';
-import { _routeConfig as routeConfig5 } from '../../../src/routes/users/[id]/+page.server';
+import { _routeConfig as routeConfig4 } from '../../../src/routes/test-no-validation/+page';
+import { _routeConfig as routeConfig5 } from '../../../src/routes/test-partial/[id]/+page';
+import { _routeConfig as routeConfig6 } from '../../../src/routes/test-search-only/+page';
+import { _routeConfig as routeConfig7 } from '../../../src/routes/type-test/[id]/+page.server';
+import { _routeConfig as routeConfig8 } from '../../../src/routes/users/[id]/+page.server';
 
 export const serverRouteConfig = {
   '/[id]': {
@@ -28,13 +31,25 @@ export const serverRouteConfig = {
           paramsValidation: routeConfig3.paramsValidation,
           searchParamsValidation: routeConfig3.searchParamsValidation,
         },
+  '/test-no-validation': {
+          paramsValidation: undefined,
+          searchParamsValidation: undefined,
+        },
+  '/test-partial/[id]': {
+          paramsValidation: routeConfig5.paramsValidation,
+          searchParamsValidation: undefined,
+        },
+  '/test-search-only': {
+          paramsValidation: undefined,
+          searchParamsValidation: routeConfig6.searchParamsValidation,
+        },
   '/type-test/[id]': {
-          paramsValidation: routeConfig4.paramsValidation,
-          searchParamsValidation: routeConfig4.searchParamsValidation,
+          paramsValidation: routeConfig7.paramsValidation,
+          searchParamsValidation: routeConfig7.searchParamsValidation,
         },
   '/users/[id]': {
-          paramsValidation: routeConfig5.paramsValidation,
-          searchParamsValidation: routeConfig5.searchParamsValidation,
+          paramsValidation: routeConfig8.paramsValidation,
+          searchParamsValidation: routeConfig8.searchParamsValidation,
         },
   '/': {
           paramsValidation: undefined,
@@ -103,7 +118,7 @@ export const serverRouteConfig = {
 } as const;
 
 // Export complete route keys for type checking (server has full visibility)
-export type ServerRouteKeys = '/[id]' | '/api/users/[id]' | '/products/[id]' | '/server/[id]' | '/type-test/[id]' | '/users/[id]' | '/' | '/error' | '/optional/[[slug]]' | '/store/[id]';
+export type ServerRouteKeys = '/[id]' | '/api/users/[id]' | '/products/[id]' | '/server/[id]' | '/test-no-validation' | '/test-partial/[id]' | '/test-search-only' | '/type-test/[id]' | '/users/[id]' | '/' | '/error' | '/optional/[[slug]]' | '/store/[id]';
 
 // Export complete type mapping for schema inference (server has full visibility)
 export type ServerRouteTypeMap = {
@@ -111,8 +126,11 @@ export type ServerRouteTypeMap = {
   '/api/users/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig1.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig1.searchParamsValidation> };
   '/products/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig2.searchParamsValidation> };
   '/server/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig3.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
-  '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig4.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig4.searchParamsValidation> };
-  '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig5.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig5.searchParamsValidation> };
+  '/test-no-validation': { params: Record<string, string>; searchParams: Record<string, unknown> };
+  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig5.paramsValidation>; searchParams: Record<string, unknown> };
+  '/test-search-only': { params: Record<string, string>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig6.searchParamsValidation> };
+  '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig7.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig7.searchParamsValidation> };
+  '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig8.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig8.searchParamsValidation> };
   '/': { params: Record<string, string>; searchParams: Record<string, unknown> };
   '/error': { params: Record<string, string>; searchParams: Record<string, unknown> };
   '/optional/[[slug]]': { params: { slug?: string }; searchParams: Record<string, unknown> };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -102,6 +102,11 @@ export interface RouteConfig {
 	[address: string]: RouteDetails;
 }
 
+export interface SingleRouteConfig {
+	paramsValidation?: StandardSchemaV1<unknown, unknown>;
+	searchParamsValidation?: StandardSchemaV1<unknown, unknown>;
+}
+
 export type ParamsType<Config extends RouteConfig, Address extends keyof Config> =
 	Config[Address]['paramsValidation'] extends StandardSchemaV1<infer T, unknown>
 		? T

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,7 @@
 export { skRoutes } from './skRoutes.svelte.js';
-export type { RouteConfig } from './skRoutes.svelte.js';
+export type { RouteConfig, SingleRouteConfig } from './skRoutes.svelte.js';
 
 export { skRoutesServer } from './skRoutes-server.js';
-export type { ServerRouteConfig } from './skRoutes-server.js';
+export type { ServerRouteConfig, SingleServerRouteConfig } from './skRoutes-server.js';
 
 export { skRoutesPlugin } from './vite-plugin-skroutes.js';

--- a/src/lib/skRoutes-server.ts
+++ b/src/lib/skRoutes-server.ts
@@ -3,6 +3,7 @@ import {
 	createUrlGenerator,
 	createUpdateParams,
 	type RouteConfig,
+	type SingleRouteConfig,
 	type ParamsType,
 	type SearchParamsType
 } from './helpers.js';
@@ -12,6 +13,12 @@ import {
  * Extends the base RouteConfig for use in server-side contexts.
  */
 export interface ServerRouteConfig extends RouteConfig {}
+
+/**
+ * Single server-side route configuration interface.
+ * Represents the configuration for a single route in server-side contexts.
+ */
+export interface SingleServerRouteConfig extends SingleRouteConfig {}
 
 /**
  * Creates a server-side URL generation and route information system for SvelteKit applications.

--- a/src/lib/skRoutes.svelte.ts
+++ b/src/lib/skRoutes.svelte.ts
@@ -6,6 +6,7 @@ import {
 	createUrlGenerator,
 	createUpdateParams,
 	type RouteConfig,
+	type SingleRouteConfig,
 	type UrlGeneratorInput,
 	type UrlGeneratorResult,
 	type ParamsType,
@@ -16,7 +17,7 @@ import {
 import { throttledSync } from './helpers.svelte.js';
 import { isEqual } from 'lodash-es';
 
-export type { RouteConfig, UrlGeneratorInput, UrlGeneratorResult };
+export type { RouteConfig, SingleRouteConfig, UrlGeneratorInput, UrlGeneratorResult };
 
 /**
  * Defines how route updates should be handled when parameters change.

--- a/src/lib/skRoutes.test.ts
+++ b/src/lib/skRoutes.test.ts
@@ -47,23 +47,16 @@ describe('skRoutes with Standard Schema', () => {
 		expect(result.url).toContain('/error');
 	});
 
-	it('should work with pageInfo', () => {
-		const mockPageData = {
-			params: { id: 'user123' },
-			url: { search: '?tab=settings&page=2' }
-		};
+	it('should validate and generate URLs correctly with default parameters', () => {
+		const result = urlGenerator({
+			address: '/users/[id]',
+			paramsValue: { id: 'user456' },
+			searchParamsValue: {}
+		});
 
-		const { current } = skRoutes({
-			config: {
-				'/users/[id]': {
-					paramsValidation: userParamsSchema,
-					searchParamsValidation: userSearchParamsSchema
-				}
-			},
-			errorURL: '/error'
-		}).pageInfo('/users/[id]', () => mockPageData);
-
-		expect(current.params).toEqual({ id: 'user123' });
-		expect(current.searchParams).toEqual({ tab: 'settings', page: 2 });
+		expect(result.error).toBe(false);
+		expect(result.url).toBe('/users/user456');
+		expect(result.params).toEqual({ id: 'user456' });
+		expect(result.searchParams).toEqual({});
 	});
 });

--- a/src/lib/vite-plugin-skroutes.ts
+++ b/src/lib/vite-plugin-skroutes.ts
@@ -15,6 +15,8 @@ interface SchemaDefinition {
 	routePath: string;
 	filePath: string;
 	routeConfig?: string;
+	hasParamsValidation?: boolean;
+	hasSearchParamsValidation?: boolean;
 }
 
 export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
@@ -230,9 +232,16 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 					`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
 				);
 
+				const paramsValidation = schema.hasParamsValidation 
+					? `${schemaAlias}.paramsValidation` 
+					: 'undefined';
+				const searchParamsValidation = schema.hasSearchParamsValidation 
+					? `${schemaAlias}.searchParamsValidation` 
+					: 'undefined';
+
 				const entry = `'${schema.routePath}': {
-          paramsValidation: ${schemaAlias}.paramsValidation,
-          searchParamsValidation: ${schemaAlias}.searchParamsValidation,
+          paramsValidation: ${paramsValidation},
+          searchParamsValidation: ${searchParamsValidation},
         }`;
 
 				configEntries.push(entry);
@@ -272,9 +281,13 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 				const schemaAlias = `routeConfig${index}`;
 
 				if (schema.routeConfig) {
-					// Use proper type inference
-					const paramsType = `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>`;
-					const searchParamsType = `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>`;
+					// Use proper type inference with conditional logic
+					const paramsType = schema.hasParamsValidation 
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>` 
+						: 'Record<string, string>';
+					const searchParamsType = schema.hasSearchParamsValidation 
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>` 
+						: 'Record<string, unknown>';
 
 					return `  '${schema.routePath}': { params: ${paramsType}; searchParams: ${searchParamsType} }`;
 				}
@@ -354,9 +367,16 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 					`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
 				);
 
+				const paramsValidation = schema.hasParamsValidation 
+					? `${schemaAlias}.paramsValidation` 
+					: 'undefined';
+				const searchParamsValidation = schema.hasSearchParamsValidation 
+					? `${schemaAlias}.searchParamsValidation` 
+					: 'undefined';
+
 				const entry = `'${schema.routePath}': {
-          paramsValidation: ${schemaAlias}.paramsValidation,
-          searchParamsValidation: ${schemaAlias}.searchParamsValidation,
+          paramsValidation: ${paramsValidation},
+          searchParamsValidation: ${searchParamsValidation},
         }`;
 
 				configEntries.push(entry);
@@ -396,9 +416,13 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 				const schemaAlias = `routeConfig${index}`;
 
 				if (schema.routeConfig) {
-					// Use proper type inference
-					const paramsType = `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>`;
-					const searchParamsType = `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>`;
+					// Use proper type inference with conditional logic
+					const paramsType = schema.hasParamsValidation 
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>` 
+						: 'Record<string, string>';
+					const searchParamsType = schema.hasSearchParamsValidation 
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>` 
+						: 'Record<string, unknown>';
 
 					return `  '${schema.routePath}': { params: ${paramsType}; searchParams: ${searchParamsType} }`;
 				}
@@ -476,10 +500,16 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 					const routeConfigMatch = content.match(routeConfigPattern);
 
 					if (routeConfigMatch) {
+						// Check if paramsValidation and searchParamsValidation exist as properties in _routeConfig
+						const hasParamsValidation = /paramsValidation\s*:/gm.test(content);
+						const hasSearchParamsValidation = /searchParamsValidation\s*:/gm.test(content);
+						
 						schemas.push({
 							routePath,
 							filePath: fullPath,
-							routeConfig: '_routeConfig'
+							routeConfig: '_routeConfig',
+							hasParamsValidation,
+							hasSearchParamsValidation
 						});
 					}
 				}
@@ -515,10 +545,16 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 					const routeConfigMatch = content.match(routeConfigPattern);
 
 					if (routeConfigMatch) {
+						// Check if paramsValidation and searchParamsValidation exist as properties in _routeConfig
+						const hasParamsValidation = /paramsValidation\s*:/gm.test(content);
+						const hasSearchParamsValidation = /searchParamsValidation\s*:/gm.test(content);
+						
 						schemas.push({
 							routePath,
 							filePath: fullPath,
-							routeConfig: '_routeConfig'
+							routeConfig: '_routeConfig',
+							hasParamsValidation,
+							hasSearchParamsValidation
 						});
 					}
 				}

--- a/src/routes/test-no-validation/+page.svelte
+++ b/src/routes/test-no-validation/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	export let data;
+</script>
+
+<h1>Test No Validation Route</h1>
+<p>{data.message}</p>
+<p>This route has an empty _routeConfig with no validation properties.</p>

--- a/src/routes/test-no-validation/+page.ts
+++ b/src/routes/test-no-validation/+page.ts
@@ -1,0 +1,10 @@
+// Test route with no validation properties at all
+export const _routeConfig = {
+	// Empty config object - no paramsValidation or searchParamsValidation
+};
+
+export const load = () => {
+	return {
+		message: 'This route has no validation'
+	};
+};

--- a/src/routes/test-partial/[id]/+page.svelte
+++ b/src/routes/test-partial/[id]/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	export let data;
+</script>
+
+<h1>Test Partial Route</h1>
+<p>ID: {data.id}</p>
+<p>This route only has paramsValidation, no searchParamsValidation.</p>

--- a/src/routes/test-partial/[id]/+page.ts
+++ b/src/routes/test-partial/[id]/+page.ts
@@ -1,0 +1,13 @@
+import type { RouteConfigDefinition } from '$lib/route-config-types';
+import z from 'zod';
+
+// Test route with only paramsValidation - no searchParamsValidation
+export const _routeConfig = {
+	paramsValidation: z.object({ id: z.string().min(1) })
+} satisfies RouteConfigDefinition;
+
+export const load = ({ params }: any) => {
+	return {
+		id: params.id
+	};
+};

--- a/src/routes/test-search-only/+page.svelte
+++ b/src/routes/test-search-only/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	export let data;
+</script>
+
+<h1>Test Search Only Route</h1>
+<p>Query: {data.query}</p>
+<p>Limit: {data.limit}</p>
+<p>This route only has searchParamsValidation, no paramsValidation.</p>

--- a/src/routes/test-search-only/+page.ts
+++ b/src/routes/test-search-only/+page.ts
@@ -1,0 +1,17 @@
+import type { RouteConfigDefinition } from '$lib/route-config-types';
+import z from 'zod';
+
+// Test route with only searchParamsValidation - no paramsValidation
+export const _routeConfig = {
+	searchParamsValidation: z.object({
+		query: z.string().optional(),
+		limit: z.coerce.number().positive().default(10)
+	})
+} satisfies RouteConfigDefinition;
+
+export const load = ({ url }: any) => {
+	return {
+		query: url.searchParams.get('query') || '',
+		limit: parseInt(url.searchParams.get('limit') || '10')
+	};
+};

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest';
+
+// Mock SvelteKit globals
+Object.defineProperty(globalThis, '__SVELTEKIT_PAYLOAD__', {
+	value: { data: {} },
+	writable: true
+});
+
+// Mock SvelteKit's goto function
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidate: vi.fn(() => Promise.resolve()),
+	invalidateAll: vi.fn(() => Promise.resolve()),
+	preloadData: vi.fn(() => Promise.resolve()),
+	preloadCode: vi.fn(() => Promise.resolve())
+}));
+
+// Mock browser environment
+vi.mock('$app/environment', () => ({
+	browser: false,
+	dev: true,
+	building: false,
+	version: 'test'
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
 		})
 	],
 	test: {
-		include: ['src/**/*.{test,spec}.{js,ts}']
+		include: ['src/**/*.{test,spec}.{js,ts}'],
+		environment: 'jsdom',
+		setupFiles: ['./src/test-setup.ts']
 	},
 	server: {
 		allowedHosts: true


### PR DESCRIPTION
This pull request enhances the route configuration system to support routes with partial or missing validation schemas, improving flexibility and type safety. It updates the code generation logic, type definitions, and adds new test routes to ensure correct handling of routes with no validation, only params validation, or only search params validation.

**Route configuration and type system improvements:**

- Updated the code generation in `vite-plugin-skroutes.ts` to detect and correctly handle routes that lack `paramsValidation` and/or `searchParamsValidation`, ensuring generated configs use `undefined` and fallback types (`Record<string, string>` or `Record<string, unknown>`) as appropriate. [[1]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fR18-R19) [[2]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fR235-R244) [[3]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fL275-R290) [[4]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fR370-R379) [[5]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fL399-R425) [[6]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fR503-R512) [[7]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fR548-R557)
- Updated the generated client and server route config files to include new test routes (`/test-no-validation`, `/test-partial/[id]`, `/test-search-only`) and apply the new conditional type logic for their params and search params. [[1]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41R8-R28) [[2]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L191-R213) [[3]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L11-R15) [[4]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691R34-R52) [[5]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L106-R133)
- Added new type definitions for `SingleRouteConfig` and `SingleServerRouteConfig` to represent individual route config objects, and re-exported them for use in other modules. [[1]](diffhunk://#diff-26999e6f9a7fac03a622245890c5bb7f2d49a102fc8b4aaed94001b7be8d7fb3R105-R109) [[2]](diffhunk://#diff-7c459e8d9110419454721d14d5b340f6df89b2cab1c2b3e4f418a687f65de256R6) [[3]](diffhunk://#diff-7c459e8d9110419454721d14d5b340f6df89b2cab1c2b3e4f418a687f65de256R17-R22) [[4]](diffhunk://#diff-ef8cd69e473dca5d24786daff7587583b1c6bf012c00240f6c725365025512feR9) [[5]](diffhunk://#diff-ef8cd69e473dca5d24786daff7587583b1c6bf012c00240f6c725365025512feL19-R20)

**Test/demo routes:**

- Added three new test routes to demonstrate and verify the handling of routes with: no validation (`/test-no-validation`), only params validation (`/test-partial/[id]`), and only search params validation (`/test-search-only`). Each includes both a `.ts` and a `.svelte` file. [[1]](diffhunk://#diff-c7967fb268080e566dc299b2d8ee7d639d8d53d065f6c1919c7602ac263b4171R1-R7) [[2]](diffhunk://#diff-4d8ecd15081b2569fdfbe3c9f7c32700811c6bb8dc24a8a9033e414076248e8bR1-R10) [src/routes/test-partial/[id]/+page.svelteR1-R7](diffhunk://#diff-e264f2af0411a418e5d07469b56be4bebac2e474b39d1dca2ba96fa35b875782R1-R7), [src/routes/test-partial/[id]/+page.tsR1-R13](diffhunk://#diff-ba9cf46f4a4921209570e18415bd38160339886f7357c18e404ac2d11616b095R1-R13), [[3]](diffhunk://#diff-65d52ae008f30483fd0b4eeb1838cf65bed49cac3059dfbc20dadc3d7441a2c3R1-R8) [[4]](diffhunk://#diff-52d4e2ef64d48fd0a6d07001503eb2588796c4b21b9ce1f91717fce18f63708cR1-R17)