### PR TITLE
Improved Fallback Options and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,15 @@ export default defineConfig({
 			// Required: URL to redirect to when validation fails
 			errorURL: '/error',
 			
+			// Optional: Directory containing SvelteKit routes (relative to project root)
+			routesDirectory: 'src/routes', // default: 'src/routes'
+			
 			// Optional: Additional imports for your validation schemas
 			imports: ["import { z } from 'zod';"],
 			
 			// Optional: How to handle routes without explicit validation
-			unconfiguredParams: 'allowAll', // 'allowAll' | 'never' | 'simple' | 'strict' | 'deriveParams'
-			unconfiguredSearchParams: 'allowAll',
+			unconfiguredParams: 'deriveParams', // 'allowAll' | 'never' | 'simple' | 'strict' | 'deriveParams' (default)
+			unconfiguredSearchParams: 'never', // 'allowAll' | 'never' | 'simple' | 'strict' (default)
 			
 			// Optional: Custom paths for generated files
 			clientOutputPath: 'src/lib/.generated/skroutes-client-config.ts',
@@ -657,11 +660,14 @@ interface PluginOptions {
 	/** Manual route configurations to include */
 	baseConfig?: Record<string, any>; // default: {}
 	
+	/** Directory containing SvelteKit routes relative to project root */
+	routesDirectory?: string; // default: 'src/routes'
+	
 	/** Strategy for handling unconfigured route parameters */
-	unconfiguredParams?: 'allowAll' | 'never' | 'simple' | 'strict' | 'deriveParams'; // default: 'allowAll'
+	unconfiguredParams?: 'allowAll' | 'never' | 'simple' | 'strict' | 'deriveParams'; // default: 'deriveParams'
 	
 	/** Strategy for handling unconfigured search parameters */
-	unconfiguredSearchParams?: 'allowAll' | 'never' | 'simple' | 'strict'; // default: 'allowAll'
+	unconfiguredSearchParams?: 'allowAll' | 'never' | 'simple' | 'strict'; // default: 'never'
 }
 ```
 
@@ -669,6 +675,10 @@ interface PluginOptions {
 
 #### 1. **Strategy Selection**
 ```typescript
+// Default configuration (recommended for most projects)
+unconfiguredParams: 'deriveParams',  // Auto-derives exact parameters from route paths (NEW DEFAULT!)
+unconfiguredSearchParams: 'never'    // Forces explicit search param configuration (NEW DEFAULT!)
+
 // For new projects - strict validation
 unconfiguredParams: 'strict',        // Prevents accidental usage
 unconfiguredSearchParams: 'never',   // Forces explicit configuration
@@ -680,10 +690,6 @@ unconfiguredSearchParams: 'simple',  // Optional parameters
 // For maximum flexibility
 unconfiguredParams: 'allowAll',      // Accepts any parameters
 unconfiguredSearchParams: 'allowAll' // Accepts any search params
-
-// For automatic route parameter detection (NEW!)
-unconfiguredParams: 'deriveParams',  // Derives exact parameters from route paths
-unconfiguredSearchParams: 'never'    // Forces explicit search param configuration
 ```
 
 #### 2. **File Organization**
@@ -714,6 +720,27 @@ const config = import.meta.env.SSR
 	? await import('$lib/.generated/skroutes-server-config')
 	: await import('$lib/.generated/skroutes-client-config');
 ```
+
+#### 4. **Custom Routes Directory**
+```typescript
+// For projects with non-standard directory structure
+skRoutesPlugin({
+  routesDirectory: 'app/routes',     // Custom routes location
+  clientOutputPath: 'src/generated/client-routes.ts',
+  serverOutputPath: 'src/generated/server-routes.ts'
+})
+
+// For monorepos or custom setups
+skRoutesPlugin({
+  routesDirectory: 'apps/web/src/routes',  // Nested routes directory
+  errorURL: '/error'
+})
+```
+
+**Why customize the routes directory?**
+- **Monorepos**: Different apps may have routes in different locations
+- **Migration**: Gradually moving from non-standard directory structures
+- **Custom setup**: Projects with unique architectural requirements
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A TypeScript-first SvelteKit library for type-safe URL generation and route parameter validation using Standard Schema.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Features](#features)
+- [Quick Start](#quick-start)
+  - [Vite Plugin Setup (Recommended)](#4-vite-plugin-for-auto-generated-routes-recommended)
+  - [Manual Configuration](#manual-configuration)
+- [Advanced Usage](#advanced-usage)
+- [Vite Plugin Architecture](#vite-plugin-architecture)
+- [API Reference](#api-reference)  
+- [Migration Guide](#migration-guide)
+- [Contributing](#contributing)
+
 ## Installation
 
 ```bash
@@ -12,19 +25,33 @@ pnpm add skroutes
 
 ## Features
 
-- 🔒 **Full Type Safety**: Route parameters and search parameters are fully typed based on your schema configuration
+### 🚀 **Auto-Generation & Zero Config**
+- 🔄 **Vite Plugin Integration**: Automatically discovers routes from your SvelteKit file structure
+- 🎯 **Zero Manual Configuration**: No need to manually register routes - just add `_routeConfig` exports
+- ⚡ **Hot Reload**: Instant type updates when you modify route files
+- 🏗️ **Smart Type Generation**: Generates precise TypeScript types from your validation schemas
+- 🌍 **Dual Config System**: Optimized client/server configurations for different environments
+
+### 🔒 **Type Safety & Validation**
 - 🏷️ **Standard Schema Support**: Works with Zod, Valibot, ArkType, and any Standard Schema-compliant library  
 - 📝 **Type-safe URL generation** with automatic validation and proper return types
-- 🛠️ **Easy URL manipulation** with strongly typed parameter updates
-- 🎨 **Reactive state management** with throttled URL updates and Svelte 5 runes support
+- 🚦 **Compile-time Route Validation**: TypeScript catches invalid routes and parameter types
+- 🎯 **Parameter Strategy System**: Flexible handling of unconfigured routes (`allowAll`, `never`, `simple`, `strict`)
+- 🎯 **Non-Optional Results**: `params` and `searchParams` are never undefined - no optional chaining needed
+
+### 🎨 **Reactive State Management**
+- 🛠️ **Easy URL manipulation** with strongly typed parameter updates  
 - 🔄 **Bi-directional synchronization**: Changes flow seamlessly between URL state and component state
 - ⚡ **Throttled updates**: Built-in throttling prevents excessive URL changes during rapid state updates
 - 🎯 **Direct binding**: Bind form inputs directly to URL parameters with automatic synchronization
-- 🚦 **TypeScript validation** of route addresses with compile-time checking
 - 💾 **Unsaved changes detection**: Track when internal state differs from URL state
 - 🔄 **Reset functionality**: Easily revert changes back to the current URL state
+
+### 🛠️ **Developer Experience**
+- 🎨 **Svelte 5 Runes Support**: Full compatibility with modern Svelte reactive patterns
 - 📊 **Debug mode**: Comprehensive logging to understand state synchronization flow
-- 🎯 **Non-Optional Results**: `params` and `searchParams` are never undefined - no optional chaining needed!
+- 🔧 **Flexible Configuration**: Extensive plugin options for customization
+- 📁 **Clean File Organization**: Co-locate validation with route logic
 
 ## Quick Start
 
@@ -153,12 +180,14 @@ const userTab = userUrl.searchParams.tab; // ✅ Direct access, no userUrl.searc
 </div>
 ```
 
-### 4. Auto-Generated Routes with Vite Plugin
+### 4. Vite Plugin for Auto-Generated Routes (Recommended)
 
-For the best developer experience, use the Vite plugin to automatically generate typed routes:
+**The Vite plugin is the recommended approach** for using skRoutes. It automatically scans your SvelteKit route files and generates fully-typed configurations with zero manual setup.
 
-```javascript
-// vite.config.js
+#### Plugin Setup
+
+```typescript
+// vite.config.ts
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import { skRoutesPlugin } from 'skroutes/plugin';
@@ -167,25 +196,153 @@ export default defineConfig({
 	plugins: [
 		sveltekit(),
 		skRoutesPlugin({
+			// Required: URL to redirect to when validation fails
+			errorURL: '/error',
+			
+			// Optional: Additional imports for your validation schemas
 			imports: ["import { z } from 'zod';"],
-			errorURL: '/error'
+			
+			// Optional: How to handle routes without explicit validation
+			unconfiguredParams: 'allowAll', // 'allowAll' | 'never' | 'simple' | 'strict'
+			unconfiguredSearchParams: 'allowAll',
+			
+			// Optional: Custom paths for generated files
+			clientOutputPath: 'src/lib/.generated/skroutes-client-config.ts',
+			serverOutputPath: 'src/lib/.generated/skroutes-server-config.ts',
+			
+			// Optional: Include server-side files in scanning
+			includeServerFiles: true,
+			
+			// Optional: Manual route configs to include
+			baseConfig: {
+				'/api/health': { 
+					paramsValidation: undefined, 
+					searchParamsValidation: undefined 
+				}
+			}
 		})
 	]
 });
 ```
 
-Then use the auto-generated routes:
+#### Configure Route Validation
+
+Add validation to your route files using `_routeConfig`:
 
 ```typescript
-// Import from the auto-generated file
-import { urlGenerator, pageInfo } from '$lib/auto-skroutes';
+// src/routes/users/[id]/+page.ts
+import { z } from 'zod';
+
+// Export validation configuration
+export const _routeConfig = {
+	paramsValidation: z.object({
+		id: z.string().uuid()
+	}).parse,
+	searchParamsValidation: z.object({
+		tab: z.enum(['profile', 'settings']).optional(),
+		page: z.coerce.number().positive().optional()
+	}).parse
+};
+
+// Your normal load function
+export async function load({ params, url }) {
+	// params.id is automatically validated as UUID
+	// url.searchParams are automatically validated
+	return {
+		user: await fetchUser(params.id)
+	};
+}
+```
+
+```typescript
+// src/routes/products/[category]/+page.server.ts
+import { z } from 'zod';
+
+export const _routeConfig = {
+	paramsValidation: z.object({
+		category: z.enum(['electronics', 'clothing', 'books'])
+	}).parse,
+	searchParamsValidation: z.object({
+		sort: z.enum(['price', 'name', 'rating']).optional(),
+		minPrice: z.coerce.number().min(0).optional(),
+		maxPrice: z.coerce.number().min(0).optional()
+	}).parse
+};
+
+export async function load({ params, url }) {
+	// Fully typed and validated parameters
+	return {
+		products: await fetchProducts(params.category, {
+			sort: url.searchParams.get('sort'),
+			minPrice: url.searchParams.get('minPrice'),
+			maxPrice: url.searchParams.get('maxPrice')
+		})
+	};
+}
+```
+
+#### Use Auto-Generated Routes
+
+The plugin generates two configuration files:
+
+```typescript
+// Import the appropriate config for your environment
+import { urlGenerator, pageInfo } from '$lib/.generated/skroutes-client-config'; // Client-side
+// or
+import { urlGenerator, pageInfo } from '$lib/.generated/skroutes-server-config'; // Server-side (has access to all routes)
 
 // All your routes are automatically typed and available!
 const userUrl = urlGenerator({
-	address: '/users/[id]', // ✅ Auto-completed and type-checked
-	paramsValue: { id: 'user123' }
+	address: '/users/[id]', // ✅ Auto-completed from your route files
+	paramsValue: { id: 'user123' }, // ✅ TypeScript knows this must be a UUID
+	searchParamsValue: { tab: 'profile' } // ✅ TypeScript validates enum values
+});
+
+// Perfect type inference for all discovered routes
+const productUrl = urlGenerator({
+	address: '/products/[category]',
+	paramsValue: { category: 'electronics' }, // ✅ Only allows valid enum values
+	searchParamsValue: { sort: 'price', minPrice: 50 }
 });
 ```
+
+#### Parameter Handling Strategies
+
+The plugin provides flexible strategies for handling routes without explicit validation:
+
+```typescript
+skRoutesPlugin({
+	// Strategy for route parameters [id], [slug], etc.
+	unconfiguredParams: 'never', // No parameters allowed
+	// unconfiguredParams: 'allowAll', // Accept any string parameters
+	// unconfiguredParams: 'simple', // Optional string parameters
+	// unconfiguredParams: 'strict', // Compile-time error (prevents usage)
+	
+	// Strategy for search parameters ?page=1&sort=name
+	unconfiguredSearchParams: 'simple', // Optional string/array parameters  
+	// unconfiguredSearchParams: 'never', // No search parameters allowed
+	// unconfiguredSearchParams: 'allowAll', // Accept any search parameters
+	// unconfiguredSearchParams: 'strict', // Compile-time error (prevents usage)
+	
+	errorURL: '/error'
+});
+```
+
+**Strategy Examples:**
+
+- **`'never'`**: Routes generate `{}` types - no unconfigured parameters allowed
+- **`'allowAll'`**: Routes generate `Record<string, string>` - accepts any parameters  
+- **`'simple'`**: Routes generate `{ [key: string]?: string }` - optional parameters
+- **`'strict'`**: Routes generate `never` - TypeScript prevents usage entirely
+
+#### Hot Reload & Development
+
+The plugin automatically watches your route files and regenerates configurations when:
+- You add/remove route files
+- You modify `_routeConfig` exports
+- You change validation schemas
+
+This provides seamless development experience with instant TypeScript feedback.
 
 ## Advanced Usage
 
@@ -340,6 +497,195 @@ export const routes = skRoutes({
 });
 ```
 
+## Vite Plugin Architecture
+
+### How the Plugin Works
+
+The skRoutes Vite plugin provides a sophisticated auto-generation system that eliminates manual configuration:
+
+#### 1. **Route Discovery**
+```
+src/routes/
+├── +page.ts                    → '/' route
+├── users/[id]/
+│   ├── +page.ts               → '/users/[id]' route  
+│   └── +page.server.ts        → '/users/[id]' server config
+├── products/[category]/
+│   ├── +page.svelte          → '/products/[category]' route
+│   └── +server.ts            → '/products/[category]' API endpoint
+└── api/health/
+    └── +server.ts            → '/api/health' API route
+```
+
+The plugin automatically scans your `src/routes` directory and discovers:
+- Page routes (`+page.ts`, `+page.svelte`) 
+- Server routes (`+page.server.ts`, `+server.ts`)
+- API endpoints (`+server.ts`)
+- Route parameters from directory structure (`[id]`, `[[slug]]`)
+
+#### 2. **Configuration Detection**
+
+The plugin looks for `_routeConfig` exports in your route files:
+
+```typescript
+// Detected automatically ✅
+export const _routeConfig = {
+	paramsValidation: z.object({ id: z.string() }).parse,
+	searchParamsValidation: z.object({ tab: z.string().optional() }).parse
+};
+
+// Also detects partial configs ✅
+export const _routeConfig = {
+	paramsValidation: z.object({ id: z.string() }).parse
+	// searchParamsValidation will use the configured strategy
+};
+
+// Routes without _routeConfig use configured strategies ✅
+```
+
+#### 3. **Smart Type Generation**
+
+For each route, the plugin generates appropriate types based on:
+
+**Explicit Configuration**: Uses your validation schemas for precise typing
+```typescript
+// Your schema
+z.object({ id: z.string().uuid() })
+
+// Generated type  
+{ id: string } // with UUID validation at runtime
+```
+
+**Route Parameters**: Automatically detects from file structure
+```typescript
+// File: src/routes/posts/[slug]/comments/[id]/+page.ts
+// Generated type
+{ slug: string; id: string }
+
+// File: src/routes/blog/[[year]]/+page.ts  
+// Generated type
+{ year?: string } // Optional parameter
+```
+
+**Configured Strategies**: Uses your strategy for unconfigured routes
+```typescript
+// Strategy: 'never'
+// Generated type for routes without _routeConfig
+{ params: {}; searchParams: {} }
+
+// Strategy: 'allowAll' 
+// Generated type for routes without _routeConfig
+{ params: Record<string, string>; searchParams: Record<string, unknown> }
+```
+
+#### 4. **Dual Configuration Generation**
+
+The plugin generates two optimized configuration files:
+
+**Client Config** (`skroutes-client-config.ts`):
+- Safe for browser environments
+- Only imports from client-side files (`+page.ts`)
+- Type-only imports for server schemas (for better inference)
+- Smaller bundle size
+
+**Server Config** (`skroutes-server-config.ts`):  
+- Full access to all routes
+- Imports from both client and server files
+- Complete validation coverage
+- Used for server-side rendering
+
+#### 5. **Development Workflow**
+
+```mermaid
+graph TD
+    A[Save route file] --> B[Plugin detects change]
+    B --> C[Scan for _routeConfig]
+    C --> D[Generate types & validation]
+    D --> E[Update config files]
+    E --> F[TypeScript re-checks]
+    F --> G[Instant feedback]
+```
+
+**Hot Reload**: Changes are detected instantly and configs are regenerated
+**Type Safety**: Immediate TypeScript feedback in your editor
+**Zero Config**: No manual route registration needed
+
+### Plugin Configuration Reference
+
+```typescript
+interface PluginOptions {
+	/** URL to redirect to when validation fails */
+	errorURL: string;
+	
+	/** Path for server-side config file */
+	serverOutputPath?: string; // default: 'src/lib/.generated/skroutes-server-config.ts'
+	
+	/** Path for client-side config file */ 
+	clientOutputPath?: string; // default: 'src/lib/.generated/skroutes-client-config.ts'
+	
+	/** Additional import statements for generated files */
+	imports?: string[]; // default: []
+	
+	/** Include server files (+page.server.ts, +server.ts) in scanning */
+	includeServerFiles?: boolean; // default: true
+	
+	/** Manual route configurations to include */
+	baseConfig?: Record<string, any>; // default: {}
+	
+	/** Strategy for handling unconfigured route parameters */
+	unconfiguredParams?: 'allowAll' | 'never' | 'simple' | 'strict'; // default: 'allowAll'
+	
+	/** Strategy for handling unconfigured search parameters */
+	unconfiguredSearchParams?: 'allowAll' | 'never' | 'simple' | 'strict'; // default: 'allowAll'
+}
+```
+
+### Best Practices
+
+#### 1. **Strategy Selection**
+```typescript
+// For new projects - strict validation
+unconfiguredParams: 'strict',        // Prevents accidental usage
+unconfiguredSearchParams: 'never',   // Forces explicit configuration
+
+// For existing projects - gradual adoption  
+unconfiguredParams: 'simple',        // Allows migration
+unconfiguredSearchParams: 'simple',  // Optional parameters
+
+// For maximum flexibility
+unconfiguredParams: 'allowAll',      // Accepts any parameters
+unconfiguredSearchParams: 'allowAll' // Accepts any search params
+```
+
+#### 2. **File Organization**
+```typescript
+// ✅ Keep validation schemas close to usage
+// src/routes/users/[id]/+page.ts
+import { userSchema } from './schemas'; // Local schema file
+
+export const _routeConfig = {
+	paramsValidation: userSchema.parse
+};
+
+// ✅ Reuse schemas across related routes  
+// src/routes/users/[id]/edit/+page.ts
+import { userSchema } from '../schemas'; // Shared parent schema
+```
+
+#### 3. **Import Strategy**
+```typescript
+// ✅ Import from client config for browser code
+import { urlGenerator } from '$lib/.generated/skroutes-client-config';
+
+// ✅ Import from server config for SSR/API routes
+import { urlGenerator } from '$lib/.generated/skroutes-server-config';
+
+// ✅ Use conditional imports for universal code
+const config = import.meta.env.SSR 
+	? await import('$lib/.generated/skroutes-server-config')
+	: await import('$lib/.generated/skroutes-client-config');
+```
+
 ## API Reference
 
 ### `skRoutes(options)`
@@ -423,6 +769,96 @@ pageInfo(
 ```
 
 ## Migration Guide
+
+### From Manual Configuration to Vite Plugin
+
+**Recommended**: Migrate from manual configuration to the Vite plugin for better DX and maintainability.
+
+#### Before (Manual Configuration)
+
+```typescript
+// src/lib/routes.ts - Manual maintenance required ❌
+import { skRoutes } from 'skroutes';
+import { z } from 'zod';
+
+export const { urlGenerator, pageInfo } = skRoutes({
+	config: {
+		// Must manually add each route ❌
+		'/users/[id]': {
+			paramsValidation: z.object({ id: z.string().uuid() }).parse,
+			searchParamsValidation: z.object({
+				tab: z.enum(['profile', 'settings']).optional()
+			}).parse
+		},
+		'/products/[category]': {
+			paramsValidation: z.object({ 
+				category: z.enum(['electronics', 'clothing', 'books'])
+			}).parse
+		}
+		// Easy to forget routes, get out of sync ❌
+	},
+	errorURL: '/error'
+});
+```
+
+#### After (Vite Plugin)
+
+```typescript
+// vite.config.ts - One-time setup ✅
+export default defineConfig({
+	plugins: [
+		sveltekit(),
+		skRoutesPlugin({
+			errorURL: '/error',
+			unconfiguredParams: 'never', // Strict validation
+			unconfiguredSearchParams: 'simple'
+		})
+	]
+});
+```
+
+```typescript
+// src/routes/users/[id]/+page.ts - Validation alongside route logic ✅
+export const _routeConfig = {
+	paramsValidation: z.object({ id: z.string().uuid() }).parse,
+	searchParamsValidation: z.object({
+		tab: z.enum(['profile', 'settings']).optional()
+	}).parse
+};
+
+export async function load({ params }) {
+	// params.id is already validated as UUID ✅
+	return { user: await getUser(params.id) };
+}
+```
+
+```typescript
+// src/routes/products/[category]/+page.ts - Automatic discovery ✅
+export const _routeConfig = {
+	paramsValidation: z.object({ 
+		category: z.enum(['electronics', 'clothing', 'books'])
+	}).parse
+};
+
+// Route automatically discovered and typed ✅
+```
+
+```typescript
+// Usage stays the same ✅
+import { urlGenerator } from '$lib/.generated/skroutes-client-config';
+
+const url = urlGenerator({
+	address: '/users/[id]',
+	paramsValue: { id: 'user123' }
+});
+```
+
+**Migration Benefits:**
+- ✅ **Zero maintenance**: Routes auto-discovered from file system
+- ✅ **Co-location**: Validation lives with route logic
+- ✅ **Type safety**: Automatic TypeScript integration 
+- ✅ **Hot reload**: Instant feedback during development
+- ✅ **Server/client optimization**: Separate configs for different environments
 
 ### From Previous Versions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skroutes",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && pnpm run package",

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -2,6 +2,7 @@
 // This file only imports from client-side files and can be safely used in the browser
 import type { StandardSchemaV1 } from 'skroutes';
 
+import type { RouteConfig } from 'skroutes';
 
 // Import schema definitions from client-side page files only
 import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';
@@ -15,261 +16,338 @@ import type { _routeConfig as serverRouteConfig1002 } from '../../../src/routes/
 import type { _routeConfig as serverRouteConfig1003 } from '../../../src/routes/type-test/[id]/+page.server';
 import type { _routeConfig as serverRouteConfig1004 } from '../../../src/routes/users/[id]/+page.server';
 
+// Export validation type mapping for each route
+export type RouteValidationTypeMap = {
+	'/[id]': {
+		paramsValidation: typeof routeConfig0.paramsValidation;
+		searchParamsValidation: typeof routeConfig0.searchParamsValidation;
+	};
+	'/test-no-validation': { paramsValidation: undefined; searchParamsValidation: undefined };
+	'/test-partial/[id]': {
+		paramsValidation: typeof routeConfig2.paramsValidation;
+		searchParamsValidation: undefined;
+	};
+	'/test-search-only': {
+		paramsValidation: undefined;
+		searchParamsValidation: typeof routeConfig3.searchParamsValidation;
+	};
+	'/api/users/[id]': {
+		paramsValidation: typeof serverRouteConfig1000.paramsValidation;
+		searchParamsValidation: typeof serverRouteConfig1000.searchParamsValidation;
+	};
+	'/products/[id]': {
+		paramsValidation: typeof serverRouteConfig1001.paramsValidation;
+		searchParamsValidation: typeof serverRouteConfig1001.searchParamsValidation;
+	};
+	'/server/[id]': {
+		paramsValidation: typeof serverRouteConfig1002.paramsValidation;
+		searchParamsValidation: typeof serverRouteConfig1002.searchParamsValidation;
+	};
+	'/type-test/[id]': {
+		paramsValidation: typeof serverRouteConfig1003.paramsValidation;
+		searchParamsValidation: typeof serverRouteConfig1003.searchParamsValidation;
+	};
+	'/users/[id]': {
+		paramsValidation: typeof serverRouteConfig1004.paramsValidation;
+		searchParamsValidation: typeof serverRouteConfig1004.searchParamsValidation;
+	};
+	'/': { paramsValidation: undefined; searchParamsValidation: undefined };
+	'/error': { paramsValidation: undefined; searchParamsValidation: undefined };
+	'/optional/[[slug]]': { paramsValidation: undefined; searchParamsValidation: undefined };
+	'/store/[id]': { paramsValidation: undefined; searchParamsValidation: undefined };
+};
+
 export const clientRouteConfig = {
-  '/[id]': {
-          paramsValidation: routeConfig0.paramsValidation,
-          searchParamsValidation: routeConfig0.searchParamsValidation,
-        },
-  '/test-no-validation': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/test-partial/[id]': {
-          paramsValidation: routeConfig2.paramsValidation,
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/test-search-only': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-          searchParamsValidation: routeConfig3.searchParamsValidation,
-        },
-  '/': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/api/users/[id]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            result.id = String(v.id || '');
-            
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/error': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/optional/[[slug]]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            
-            result.slug = v.slug ? String(v.slug) : undefined;
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/products/[id]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            result.id = String(v.id || '');
-            
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/server/[id]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            result.id = String(v.id || '');
-            
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/store/[id]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            result.id = String(v.id || '');
-            
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/type-test/[id]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            result.id = String(v.id || '');
-            
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        },
-  '/users/[id]': {
-          paramsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => {
-            if (!v || typeof v !== 'object') return { value: {} };
-            const result: Record<string, string | undefined> = {};
-            result.id = String(v.id || '');
-            
-            return { value: result };
-          }
-        }
-      },
-          searchParamsValidation: {
-        '~standard': {
-          version: 1,
-          vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
-        }
-      },
-        }
-} as const;
+	'/[id]': {
+		paramsValidation: routeConfig0.paramsValidation,
+		searchParamsValidation: routeConfig0.searchParamsValidation
+	},
+	'/test-no-validation': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/test-partial/[id]': {
+		paramsValidation: routeConfig2.paramsValidation,
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/test-search-only': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		},
+		searchParamsValidation: routeConfig3.searchParamsValidation
+	},
+	'/': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/api/users/[id]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+					result.id = String(v.id || '');
+
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/error': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/optional/[[slug]]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+
+					result.slug = v.slug ? String(v.slug) : undefined;
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/products/[id]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+					result.id = String(v.id || '');
+
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/server/[id]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+					result.id = String(v.id || '');
+
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/store/[id]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+					result.id = String(v.id || '');
+
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/type-test/[id]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+					result.id = String(v.id || '');
+
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	},
+	'/users/[id]': {
+		paramsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => {
+					if (!v || typeof v !== 'object') return { value: {} };
+					const result: Record<string, string | undefined> = {};
+					result.id = String(v.id || '');
+
+					return { value: result };
+				}
+			}
+		},
+		searchParamsValidation: {
+			'~standard': {
+				version: 1,
+				vendor: 'skroutes',
+				validate: (v: any) => ({ value: {} })
+			}
+		}
+	}
+} satisfies RouteConfig as unknown as RouteValidationTypeMap;
 
 // Export route keys for type checking
-export type RouteKeys = '/[id]' | '/test-no-validation' | '/test-partial/[id]' | '/test-search-only' | '/' | '/api/users/[id]' | '/error' | '/optional/[[slug]]' | '/products/[id]' | '/server/[id]' | '/store/[id]' | '/type-test/[id]' | '/users/[id]';
+export type RouteKeys =
+	| '/[id]'
+	| '/test-no-validation'
+	| '/test-partial/[id]'
+	| '/test-search-only'
+	| '/'
+	| '/api/users/[id]'
+	| '/error'
+	| '/optional/[[slug]]'
+	| '/products/[id]'
+	| '/server/[id]'
+	| '/store/[id]'
+	| '/type-test/[id]'
+	| '/users/[id]';
 
 // Export type mapping for schema inference
 export type RouteTypeMap = {
-  '/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig0.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig0.searchParamsValidation> };
-  '/test-no-validation': { params: {}; searchParams: {} };
-  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: {} };
-  '/test-search-only': { params: {}; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
-  '/api/users/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.searchParamsValidation> };
-  '/products/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.searchParamsValidation> };
-  '/server/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.searchParamsValidation> };
-  '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.searchParamsValidation> };
-  '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.searchParamsValidation> };
-  '/': { params: {}; searchParams: {} };
-  '/error': { params: {}; searchParams: {} };
-  '/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
-  '/store/[id]': { params: { id: string }; searchParams: {} }
+	'/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof routeConfig0.paramsValidation>;
+		searchParams: StandardSchemaV1.InferOutput<typeof routeConfig0.searchParamsValidation>;
+	};
+	'/test-no-validation': { params: {}; searchParams: {} };
+	'/test-partial/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>;
+		searchParams: {};
+	};
+	'/test-search-only': {
+		params: {};
+		searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation>;
+	};
+	'/api/users/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.paramsValidation>;
+		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.searchParamsValidation>;
+	};
+	'/products/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.paramsValidation>;
+		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.searchParamsValidation>;
+	};
+	'/server/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.paramsValidation>;
+		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.searchParamsValidation>;
+	};
+	'/type-test/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.paramsValidation>;
+		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.searchParamsValidation>;
+	};
+	'/users/[id]': {
+		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.paramsValidation>;
+		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.searchParamsValidation>;
+	};
+	'/': { params: {}; searchParams: {} };
+	'/error': { params: {}; searchParams: {} };
+	'/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
+	'/store/[id]': { params: { id: string }; searchParams: {} };
 };
 
 // Convenience type aliases for accessing route param/search param types
 export type RouteParams<T extends RouteKeys> = RouteTypeMap[T]['params'];
 export type RouteSearchParams<T extends RouteKeys> = RouteTypeMap[T]['searchParams'];
 
-
 // Export plugin options for reference
 export const pluginOptions = {
-  "errorURL": "/error"
+	errorURL: '/error'
 };

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -29,8 +29,8 @@ export type RouteValidationTypeMap = {
   '/users/[id]': { paramsValidation: typeof serverRouteConfig1004.paramsValidation; searchParamsValidation: typeof serverRouteConfig1004.searchParamsValidation };
   '/': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
   '/error': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
-  '/optional/[[slug]]': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
-  '/store/[id]': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> }
+  '/optional/[[slug]]': { paramsValidation: StandardSchemaV1<any, { slug?: string }>; searchParamsValidation: StandardSchemaV1<any, {}> };
+  '/store/[id]': { paramsValidation: StandardSchemaV1<any, { id: string }>; searchParamsValidation: StandardSchemaV1<any, {}> }
 };
 
 export const clientRouteConfig = {

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -18,336 +18,276 @@ import type { _routeConfig as serverRouteConfig1004 } from '../../../src/routes/
 
 // Export validation type mapping for each route
 export type RouteValidationTypeMap = {
-	'/[id]': {
-		paramsValidation: typeof routeConfig0.paramsValidation;
-		searchParamsValidation: typeof routeConfig0.searchParamsValidation;
-	};
-	'/test-no-validation': { paramsValidation: undefined; searchParamsValidation: undefined };
-	'/test-partial/[id]': {
-		paramsValidation: typeof routeConfig2.paramsValidation;
-		searchParamsValidation: undefined;
-	};
-	'/test-search-only': {
-		paramsValidation: undefined;
-		searchParamsValidation: typeof routeConfig3.searchParamsValidation;
-	};
-	'/api/users/[id]': {
-		paramsValidation: typeof serverRouteConfig1000.paramsValidation;
-		searchParamsValidation: typeof serverRouteConfig1000.searchParamsValidation;
-	};
-	'/products/[id]': {
-		paramsValidation: typeof serverRouteConfig1001.paramsValidation;
-		searchParamsValidation: typeof serverRouteConfig1001.searchParamsValidation;
-	};
-	'/server/[id]': {
-		paramsValidation: typeof serverRouteConfig1002.paramsValidation;
-		searchParamsValidation: typeof serverRouteConfig1002.searchParamsValidation;
-	};
-	'/type-test/[id]': {
-		paramsValidation: typeof serverRouteConfig1003.paramsValidation;
-		searchParamsValidation: typeof serverRouteConfig1003.searchParamsValidation;
-	};
-	'/users/[id]': {
-		paramsValidation: typeof serverRouteConfig1004.paramsValidation;
-		searchParamsValidation: typeof serverRouteConfig1004.searchParamsValidation;
-	};
-	'/': { paramsValidation: undefined; searchParamsValidation: undefined };
-	'/error': { paramsValidation: undefined; searchParamsValidation: undefined };
-	'/optional/[[slug]]': { paramsValidation: undefined; searchParamsValidation: undefined };
-	'/store/[id]': { paramsValidation: undefined; searchParamsValidation: undefined };
+  '/[id]': { paramsValidation: typeof routeConfig0.paramsValidation; searchParamsValidation: typeof routeConfig0.searchParamsValidation };
+  '/test-no-validation': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
+  '/test-partial/[id]': { paramsValidation: typeof routeConfig2.paramsValidation; searchParamsValidation: StandardSchemaV1<any, {}> };
+  '/test-search-only': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: typeof routeConfig3.searchParamsValidation };
+  '/api/users/[id]': { paramsValidation: typeof serverRouteConfig1000.paramsValidation; searchParamsValidation: typeof serverRouteConfig1000.searchParamsValidation };
+  '/products/[id]': { paramsValidation: typeof serverRouteConfig1001.paramsValidation; searchParamsValidation: typeof serverRouteConfig1001.searchParamsValidation };
+  '/server/[id]': { paramsValidation: typeof serverRouteConfig1002.paramsValidation; searchParamsValidation: typeof serverRouteConfig1002.searchParamsValidation };
+  '/type-test/[id]': { paramsValidation: typeof serverRouteConfig1003.paramsValidation; searchParamsValidation: typeof serverRouteConfig1003.searchParamsValidation };
+  '/users/[id]': { paramsValidation: typeof serverRouteConfig1004.paramsValidation; searchParamsValidation: typeof serverRouteConfig1004.searchParamsValidation };
+  '/': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
+  '/error': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
+  '/optional/[[slug]]': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> };
+  '/store/[id]': { paramsValidation: StandardSchemaV1<any, {}>; searchParamsValidation: StandardSchemaV1<any, {}> }
 };
 
 export const clientRouteConfig = {
-	'/[id]': {
-		paramsValidation: routeConfig0.paramsValidation,
-		searchParamsValidation: routeConfig0.searchParamsValidation
-	},
-	'/test-no-validation': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/test-partial/[id]': {
-		paramsValidation: routeConfig2.paramsValidation,
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/test-search-only': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		},
-		searchParamsValidation: routeConfig3.searchParamsValidation
-	},
-	'/': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/api/users/[id]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-					result.id = String(v.id || '');
-
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/error': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/optional/[[slug]]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-
-					result.slug = v.slug ? String(v.slug) : undefined;
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/products/[id]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-					result.id = String(v.id || '');
-
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/server/[id]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-					result.id = String(v.id || '');
-
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/store/[id]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-					result.id = String(v.id || '');
-
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/type-test/[id]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-					result.id = String(v.id || '');
-
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	},
-	'/users/[id]': {
-		paramsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => {
-					if (!v || typeof v !== 'object') return { value: {} };
-					const result: Record<string, string | undefined> = {};
-					result.id = String(v.id || '');
-
-					return { value: result };
-				}
-			}
-		},
-		searchParamsValidation: {
-			'~standard': {
-				version: 1,
-				vendor: 'skroutes',
-				validate: (v: any) => ({ value: {} })
-			}
-		}
-	}
+  '/[id]': {
+          paramsValidation: routeConfig0.paramsValidation,
+          searchParamsValidation: routeConfig0.searchParamsValidation,
+        },
+  '/test-no-validation': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/test-partial/[id]': {
+          paramsValidation: routeConfig2.paramsValidation,
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/test-search-only': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+          searchParamsValidation: routeConfig3.searchParamsValidation,
+        },
+  '/': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/api/users/[id]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            result.id = String(v.id || '');
+            
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/error': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/optional/[[slug]]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            
+            result.slug = v.slug ? String(v.slug) : undefined;
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/products/[id]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            result.id = String(v.id || '');
+            
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/server/[id]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            result.id = String(v.id || '');
+            
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/store/[id]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            result.id = String(v.id || '');
+            
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/type-test/[id]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            result.id = String(v.id || '');
+            
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        },
+  '/users/[id]': {
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => {
+            if (!v || typeof v !== 'object') return { value: {} };
+            const result: Record<string, string | undefined> = {};
+            result.id = String(v.id || '');
+            
+            return { value: result };
+          }
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+        }
 } satisfies RouteConfig as unknown as RouteValidationTypeMap;
 
 // Export route keys for type checking
-export type RouteKeys =
-	| '/[id]'
-	| '/test-no-validation'
-	| '/test-partial/[id]'
-	| '/test-search-only'
-	| '/'
-	| '/api/users/[id]'
-	| '/error'
-	| '/optional/[[slug]]'
-	| '/products/[id]'
-	| '/server/[id]'
-	| '/store/[id]'
-	| '/type-test/[id]'
-	| '/users/[id]';
+export type RouteKeys = '/[id]' | '/test-no-validation' | '/test-partial/[id]' | '/test-search-only' | '/' | '/api/users/[id]' | '/error' | '/optional/[[slug]]' | '/products/[id]' | '/server/[id]' | '/store/[id]' | '/type-test/[id]' | '/users/[id]';
 
 // Export type mapping for schema inference
 export type RouteTypeMap = {
-	'/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof routeConfig0.paramsValidation>;
-		searchParams: StandardSchemaV1.InferOutput<typeof routeConfig0.searchParamsValidation>;
-	};
-	'/test-no-validation': { params: {}; searchParams: {} };
-	'/test-partial/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>;
-		searchParams: {};
-	};
-	'/test-search-only': {
-		params: {};
-		searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation>;
-	};
-	'/api/users/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.paramsValidation>;
-		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.searchParamsValidation>;
-	};
-	'/products/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.paramsValidation>;
-		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.searchParamsValidation>;
-	};
-	'/server/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.paramsValidation>;
-		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.searchParamsValidation>;
-	};
-	'/type-test/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.paramsValidation>;
-		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.searchParamsValidation>;
-	};
-	'/users/[id]': {
-		params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.paramsValidation>;
-		searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.searchParamsValidation>;
-	};
-	'/': { params: {}; searchParams: {} };
-	'/error': { params: {}; searchParams: {} };
-	'/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
-	'/store/[id]': { params: { id: string }; searchParams: {} };
+  '/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig0.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig0.searchParamsValidation> };
+  '/test-no-validation': { params: {}; searchParams: {} };
+  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: {} };
+  '/test-search-only': { params: {}; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
+  '/api/users/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.searchParamsValidation> };
+  '/products/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.searchParamsValidation> };
+  '/server/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.searchParamsValidation> };
+  '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.searchParamsValidation> };
+  '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.searchParamsValidation> };
+  '/': { params: {}; searchParams: {} };
+  '/error': { params: {}; searchParams: {} };
+  '/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
+  '/store/[id]': { params: { id: string }; searchParams: {} }
 };
 
 // Convenience type aliases for accessing route param/search param types
 export type RouteParams<T extends RouteKeys> = RouteTypeMap[T]['params'];
 export type RouteSearchParams<T extends RouteKeys> = RouteTypeMap[T]['searchParams'];
 
+
 // Export plugin options for reference
 export const pluginOptions = {
-	errorURL: '/error'
+  "errorURL": "/error"
 };

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -5,7 +5,6 @@ import type { StandardSchemaV1 } from 'skroutes';
 
 // Import schema definitions from client-side page files only
 import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';
-import { _routeConfig as routeConfig1 } from '../../../src/routes/test-no-validation/+page';
 import { _routeConfig as routeConfig2 } from '../../../src/routes/test-partial/[id]/+page';
 import { _routeConfig as routeConfig3 } from '../../../src/routes/test-search-only/+page';
 

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -30,14 +30,14 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
           searchParamsValidation: {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -59,7 +59,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -68,14 +68,14 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
           searchParamsValidation: {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -97,7 +97,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -119,7 +119,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -141,7 +141,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -163,7 +163,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -185,7 +185,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -207,7 +207,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         }
@@ -222,15 +222,15 @@ export type RouteTypeMap = {
   '/test-no-validation': { params: Record<string, string>; searchParams: Record<string, unknown> };
   '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: Record<string, unknown> };
   '/test-search-only': { params: Record<string, string>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
-  '/': { params: Record<string, string>; searchParams: Record<string, unknown> };
-  '/api/users/[id]': { params: { id: string }; searchParams: Record<string, unknown> };
-  '/error': { params: Record<string, string>; searchParams: Record<string, unknown> };
-  '/optional/[[slug]]': { params: { slug?: string }; searchParams: Record<string, unknown> };
-  '/products/[id]': { params: { id: string }; searchParams: Record<string, unknown> };
-  '/server/[id]': { params: { id: string }; searchParams: Record<string, unknown> };
-  '/store/[id]': { params: { id: string }; searchParams: Record<string, unknown> };
-  '/type-test/[id]': { params: { id: string }; searchParams: Record<string, unknown> };
-  '/users/[id]': { params: { id: string }; searchParams: Record<string, unknown> }
+  '/': { params: {}; searchParams: {} };
+  '/api/users/[id]': { params: { id: string }; searchParams: {} };
+  '/error': { params: {}; searchParams: {} };
+  '/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
+  '/products/[id]': { params: { id: string }; searchParams: {} };
+  '/server/[id]': { params: { id: string }; searchParams: {} };
+  '/store/[id]': { params: { id: string }; searchParams: {} };
+  '/type-test/[id]': { params: { id: string }; searchParams: {} };
+  '/users/[id]': { params: { id: string }; searchParams: {} }
 };
 
 // Convenience type aliases for accessing route param/search param types

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -14,15 +14,39 @@ export const clientRouteConfig = {
           searchParamsValidation: routeConfig0.searchParamsValidation,
         },
   '/test-no-validation': {
-          paramsValidation: undefined,
-          searchParamsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
         },
   '/test-partial/[id]': {
           paramsValidation: routeConfig2.paramsValidation,
-          searchParamsValidation: undefined,
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
         },
   '/test-search-only': {
-          paramsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
           searchParamsValidation: routeConfig3.searchParamsValidation,
         },
   '/': {
@@ -219,9 +243,9 @@ export type RouteKeys = '/[id]' | '/test-no-validation' | '/test-partial/[id]' |
 // Export type mapping for schema inference
 export type RouteTypeMap = {
   '/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig0.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig0.searchParamsValidation> };
-  '/test-no-validation': { params: Record<string, string>; searchParams: Record<string, unknown> };
-  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: Record<string, unknown> };
-  '/test-search-only': { params: Record<string, string>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
+  '/test-no-validation': { params: {}; searchParams: {} };
+  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: {} };
+  '/test-search-only': { params: {}; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
   '/': { params: {}; searchParams: {} };
   '/api/users/[id]': { params: { id: string }; searchParams: {} };
   '/error': { params: {}; searchParams: {} };

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -1,8 +1,8 @@
 // Auto-generated client-side config by skroutes-plugin
 // This file only imports from client-side files and can be safely used in the browser
-import type { StandardSchemaV1 } from 'skroutes';
+import type { StandardSchemaV1 } from '../index.js';
 
-import type { RouteConfig } from 'skroutes';
+import type { RouteConfig } from '../index.js';
 
 // Import schema definitions from client-side page files only
 import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -1,6 +1,6 @@
 // Auto-generated client-side config by skroutes-plugin
 // This file only imports from client-side files and can be safely used in the browser
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from 'skroutes';
 
 
 // Import schema definitions from client-side page files only
@@ -27,14 +27,20 @@ export const clientRouteConfig = {
           searchParamsValidation: routeConfig3.searchParamsValidation,
         },
   '/': {
-          paramsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/api/users/[id]': {
           paramsValidation: {
@@ -51,22 +57,28 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/error': {
-          paramsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/optional/[[slug]]': {
           paramsValidation: {
@@ -83,12 +95,12 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/products/[id]': {
           paramsValidation: {
@@ -105,12 +117,12 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/server/[id]': {
           paramsValidation: {
@@ -127,12 +139,12 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/store/[id]': {
           paramsValidation: {
@@ -149,12 +161,12 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/type-test/[id]': {
           paramsValidation: {
@@ -171,12 +183,12 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/users/[id]': {
           paramsValidation: {
@@ -193,12 +205,12 @@ export const clientRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         }
 } as const;
 

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -8,6 +8,13 @@ import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';
 import { _routeConfig as routeConfig2 } from '../../../src/routes/test-partial/[id]/+page';
 import { _routeConfig as routeConfig3 } from '../../../src/routes/test-search-only/+page';
 
+// Type-only imports from server files for better type inference
+import type { _routeConfig as serverRouteConfig1000 } from '../../../src/routes/api/users/[id]/+server';
+import type { _routeConfig as serverRouteConfig1001 } from '../../../src/routes/products/[id]/+page.server';
+import type { _routeConfig as serverRouteConfig1002 } from '../../../src/routes/server/[id]/+page.server';
+import type { _routeConfig as serverRouteConfig1003 } from '../../../src/routes/type-test/[id]/+page.server';
+import type { _routeConfig as serverRouteConfig1004 } from '../../../src/routes/users/[id]/+page.server';
+
 export const clientRouteConfig = {
   '/[id]': {
           paramsValidation: routeConfig0.paramsValidation,
@@ -246,15 +253,15 @@ export type RouteTypeMap = {
   '/test-no-validation': { params: {}; searchParams: {} };
   '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: {} };
   '/test-search-only': { params: {}; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
+  '/api/users/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1000.searchParamsValidation> };
+  '/products/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1001.searchParamsValidation> };
+  '/server/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1002.searchParamsValidation> };
+  '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1003.searchParamsValidation> };
+  '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof serverRouteConfig1004.searchParamsValidation> };
   '/': { params: {}; searchParams: {} };
-  '/api/users/[id]': { params: { id: string }; searchParams: {} };
   '/error': { params: {}; searchParams: {} };
   '/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
-  '/products/[id]': { params: { id: string }; searchParams: {} };
-  '/server/[id]': { params: { id: string }; searchParams: {} };
-  '/store/[id]': { params: { id: string }; searchParams: {} };
-  '/type-test/[id]': { params: { id: string }; searchParams: {} };
-  '/users/[id]': { params: { id: string }; searchParams: {} }
+  '/store/[id]': { params: { id: string }; searchParams: {} }
 };
 
 // Convenience type aliases for accessing route param/search param types

--- a/src/lib/.generated/skroutes-server-config.ts
+++ b/src/lib/.generated/skroutes-server-config.ts
@@ -31,15 +31,39 @@ export const serverRouteConfig = {
           searchParamsValidation: routeConfig3.searchParamsValidation,
         },
   '/test-no-validation': {
-          paramsValidation: undefined,
-          searchParamsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
         },
   '/test-partial/[id]': {
           paramsValidation: routeConfig5.paramsValidation,
-          searchParamsValidation: undefined,
+          searchParamsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
         },
   '/test-search-only': {
-          paramsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: {} })
+        }
+      },
           searchParamsValidation: routeConfig6.searchParamsValidation,
         },
   '/type-test/[id]': {
@@ -137,9 +161,9 @@ export type ServerRouteTypeMap = {
   '/api/users/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig1.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig1.searchParamsValidation> };
   '/products/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig2.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig2.searchParamsValidation> };
   '/server/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig3.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig3.searchParamsValidation> };
-  '/test-no-validation': { params: Record<string, string>; searchParams: Record<string, unknown> };
-  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig5.paramsValidation>; searchParams: Record<string, unknown> };
-  '/test-search-only': { params: Record<string, string>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig6.searchParamsValidation> };
+  '/test-no-validation': { params: {}; searchParams: {} };
+  '/test-partial/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig5.paramsValidation>; searchParams: {} };
+  '/test-search-only': { params: {}; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig6.searchParamsValidation> };
   '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig7.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig7.searchParamsValidation> };
   '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig8.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig8.searchParamsValidation> };
   '/': { params: {}; searchParams: {} };

--- a/src/lib/.generated/skroutes-server-config.ts
+++ b/src/lib/.generated/skroutes-server-config.ts
@@ -8,7 +8,6 @@ import { _routeConfig as routeConfig0 } from '../../../src/routes/[id]/+page';
 import { _routeConfig as routeConfig1 } from '../../../src/routes/api/users/[id]/+server';
 import { _routeConfig as routeConfig2 } from '../../../src/routes/products/[id]/+page.server';
 import { _routeConfig as routeConfig3 } from '../../../src/routes/server/[id]/+page.server';
-import { _routeConfig as routeConfig4 } from '../../../src/routes/test-no-validation/+page';
 import { _routeConfig as routeConfig5 } from '../../../src/routes/test-partial/[id]/+page';
 import { _routeConfig as routeConfig6 } from '../../../src/routes/test-search-only/+page';
 import { _routeConfig as routeConfig7 } from '../../../src/routes/type-test/[id]/+page.server';

--- a/src/lib/.generated/skroutes-server-config.ts
+++ b/src/lib/.generated/skroutes-server-config.ts
@@ -55,14 +55,14 @@ export const serverRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
           searchParamsValidation: {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -71,14 +71,14 @@ export const serverRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
           searchParamsValidation: {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -100,7 +100,7 @@ export const serverRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         },
@@ -122,7 +122,7 @@ export const serverRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: v || {} })
+          validate: (v: any) => ({ value: {} })
         }
       },
         }
@@ -142,10 +142,10 @@ export type ServerRouteTypeMap = {
   '/test-search-only': { params: Record<string, string>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig6.searchParamsValidation> };
   '/type-test/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig7.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig7.searchParamsValidation> };
   '/users/[id]': { params: StandardSchemaV1.InferOutput<typeof routeConfig8.paramsValidation>; searchParams: StandardSchemaV1.InferOutput<typeof routeConfig8.searchParamsValidation> };
-  '/': { params: Record<string, string>; searchParams: Record<string, unknown> };
-  '/error': { params: Record<string, string>; searchParams: Record<string, unknown> };
-  '/optional/[[slug]]': { params: { slug?: string }; searchParams: Record<string, unknown> };
-  '/store/[id]': { params: { id: string }; searchParams: Record<string, unknown> }
+  '/': { params: {}; searchParams: {} };
+  '/error': { params: {}; searchParams: {} };
+  '/optional/[[slug]]': { params: { slug?: string }; searchParams: {} };
+  '/store/[id]': { params: { id: string }; searchParams: {} }
 };
 
 // Convenience type aliases for accessing route param/search param types

--- a/src/lib/.generated/skroutes-server-config.ts
+++ b/src/lib/.generated/skroutes-server-config.ts
@@ -1,6 +1,6 @@
 // Auto-generated server-side config by skroutes-plugin
 // WARNING: This file imports from server files and should only be used server-side
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from 'skroutes';
 
 
 // Import schema definitions from both client and server files
@@ -52,24 +52,36 @@ export const serverRouteConfig = {
           searchParamsValidation: routeConfig8.searchParamsValidation,
         },
   '/': {
-          paramsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/error': {
-          paramsValidation: undefined,
+          paramsValidation: {
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/optional/[[slug]]': {
           paramsValidation: {
@@ -86,12 +98,12 @@ export const serverRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         },
   '/store/[id]': {
           paramsValidation: {
@@ -108,12 +120,12 @@ export const serverRouteConfig = {
         }
       },
           searchParamsValidation: {
-      '~standard': {
-        version: 1,
-        vendor: 'skroutes',
-        validate: (v: any) => ({ value: v || {} })
-      }
-    },
+        '~standard': {
+          version: 1,
+          vendor: 'skroutes',
+          validate: (v: any) => ({ value: v || {} })
+        }
+      },
         }
 } as const;
 

--- a/src/lib/.generated/skroutes-server-config.ts
+++ b/src/lib/.generated/skroutes-server-config.ts
@@ -1,6 +1,6 @@
 // Auto-generated server-side config by skroutes-plugin
 // WARNING: This file imports from server files and should only be used server-side
-import type { StandardSchemaV1 } from 'skroutes';
+import type { StandardSchemaV1 } from '../index.js';
 
 
 // Import schema definitions from both client and server files

--- a/src/lib/auto-skroutes-universal.ts
+++ b/src/lib/auto-skroutes-universal.ts
@@ -1,0 +1,7 @@
+import { skRoutesUniversal } from './skRoutes-universal';
+import { clientRouteConfig } from './.generated/skroutes-client-config';
+
+export const { universalPageInfo } = skRoutesUniversal({
+	errorURL: '/',
+	config: clientRouteConfig
+});

--- a/src/lib/auto-skroutes.svelte.ts
+++ b/src/lib/auto-skroutes.svelte.ts
@@ -10,47 +10,9 @@ import {
 
 export type { RouteKeys, RouteTypeMap, RouteParams, RouteSearchParams };
 
-const { pageInfo: _pageInfo, urlGenerator } = skRoutes({
+
+
+export const { pageInfo, urlGenerator } = skRoutes({
 	config: clientRouteConfig,
 	errorURL: pluginOptions.errorURL || '/error'
 });
-
-// Type-safe wrapper that uses the explicit RouteTypeMap instead of inferring from runtime config
-export const pageInfo = <Address extends RouteKeys>(
-	routeId: Address,
-	pageInfo: () => { params: Record<string, string>; url: { search: string } },
-	config?: {
-		updateDelay?: number;
-		onUpdate?: (newUrl: string) => unknown;
-		updateAction?: 'goto' | 'nil';
-		debug?: boolean;
-	}
-) => {
-	// Get the original pageInfo result
-	const original = _pageInfo(routeId, pageInfo, config);
-
-	// Return the same object but with corrected types based on RouteTypeMap
-	return {
-		...original,
-		current: {
-			get params() {
-				return original.current.params as RouteTypeMap[Address]['params'];
-			},
-			set params(value: RouteTypeMap[Address]['params']) {
-				original.current.params = value as any;
-			},
-			get searchParams() {
-				return original.current.searchParams as RouteTypeMap[Address]['searchParams'];
-			},
-			set searchParams(value: RouteTypeMap[Address]['searchParams']) {
-				original.current.searchParams = value as any;
-			}
-		},
-		updateParams: (updates: {
-			params?: Partial<RouteTypeMap[Address]['params']>;
-			searchParams?: Partial<RouteTypeMap[Address]['searchParams']>;
-		}) => original.updateParams(updates as any)
-	} as const;
-};
-
-export { urlGenerator };

--- a/src/lib/auto-skroutes.svelte.ts
+++ b/src/lib/auto-skroutes.svelte.ts
@@ -1,4 +1,4 @@
-import { skRoutes } from './skRoutes.svelte.js';
+import { skRoutes, type RouteConfig } from './skRoutes.svelte.js';
 import {
 	clientRouteConfig,
 	type RouteKeys,
@@ -10,7 +10,47 @@ import {
 
 export type { RouteKeys, RouteTypeMap, RouteParams, RouteSearchParams };
 
-export const { pageInfo, urlGenerator } = skRoutes({
+const { pageInfo: _pageInfo, urlGenerator } = skRoutes({
 	config: clientRouteConfig,
 	errorURL: pluginOptions.errorURL || '/error'
 });
+
+// Type-safe wrapper that uses the explicit RouteTypeMap instead of inferring from runtime config
+export const pageInfo = <Address extends RouteKeys>(
+	routeId: Address,
+	pageInfo: () => { params: Record<string, string>; url: { search: string } },
+	config?: {
+		updateDelay?: number;
+		onUpdate?: (newUrl: string) => unknown;
+		updateAction?: 'goto' | 'nil';
+		debug?: boolean;
+	}
+) => {
+	// Get the original pageInfo result
+	const original = _pageInfo(routeId, pageInfo, config);
+
+	// Return the same object but with corrected types based on RouteTypeMap
+	return {
+		...original,
+		current: {
+			get params() {
+				return original.current.params as RouteTypeMap[Address]['params'];
+			},
+			set params(value: RouteTypeMap[Address]['params']) {
+				original.current.params = value as any;
+			},
+			get searchParams() {
+				return original.current.searchParams as RouteTypeMap[Address]['searchParams'];
+			},
+			set searchParams(value: RouteTypeMap[Address]['searchParams']) {
+				original.current.searchParams = value as any;
+			}
+		},
+		updateParams: (updates: {
+			params?: Partial<RouteTypeMap[Address]['params']>;
+			searchParams?: Partial<RouteTypeMap[Address]['searchParams']>;
+		}) => original.updateParams(updates as any)
+	} as const;
+};
+
+export { urlGenerator };

--- a/src/lib/auto-skroutes.svelte.ts
+++ b/src/lib/auto-skroutes.svelte.ts
@@ -1,16 +1,5 @@
-import { skRoutes, type RouteConfig } from './skRoutes.svelte.js';
-import {
-	clientRouteConfig,
-	type RouteKeys,
-	type RouteTypeMap,
-	type RouteParams,
-	type RouteSearchParams,
-	pluginOptions
-} from './.generated/skroutes-client-config.js';
-
-export type { RouteKeys, RouteTypeMap, RouteParams, RouteSearchParams };
-
-
+import { skRoutes } from './skRoutes.svelte.js';
+import { clientRouteConfig, pluginOptions } from './.generated/skroutes-client-config.js';
 
 export const { pageInfo, urlGenerator } = skRoutes({
 	config: clientRouteConfig,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,3 +5,5 @@ export { skRoutesServer } from './skRoutes-server.js';
 export type { ServerRouteConfig, SingleServerRouteConfig } from './skRoutes-server.js';
 
 export { skRoutesPlugin } from './vite-plugin-skroutes.js';
+
+export type { StandardSchemaV1 } from '@standard-schema/spec';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,9 @@ export type { RouteConfig, SingleRouteConfig } from './skRoutes.svelte.js';
 export { skRoutesServer } from './skRoutes-server.js';
 export type { ServerRouteConfig, SingleServerRouteConfig } from './skRoutes-server.js';
 
+export { skRoutesUniversal } from './skRoutes-universal.js';
+export type { UniversalRouteConfig, SingleUniversalRouteConfig } from './skRoutes-universal.js';
+
 export { skRoutesPlugin } from './vite-plugin-skroutes.js';
 
 export type { StandardSchemaV1 } from '@standard-schema/spec';

--- a/src/lib/skRoutes-universal.ts
+++ b/src/lib/skRoutes-universal.ts
@@ -1,0 +1,188 @@
+import {
+	getUrlParams,
+	createUrlGenerator,
+	createUpdateParams,
+	type RouteConfig,
+	type SingleRouteConfig,
+	type ParamsType,
+	type SearchParamsType,
+	type ValidatedParamsType,
+	type ValidatedSearchParamsType
+} from './helpers.js';
+
+/**
+ * Universal route configuration interface.
+ * Can be used in both server and client contexts.
+ */
+export interface UniversalRouteConfig extends RouteConfig {}
+
+/**
+ * Single universal route configuration interface.
+ * Represents the configuration for a single route in universal contexts.
+ */
+export interface SingleUniversalRouteConfig extends SingleRouteConfig {}
+
+/**
+ * Creates a universal URL generation and route information system for SvelteKit applications.
+ * 
+ * This function provides utilities that work in both server-side (SSR) and client-side contexts,
+ * making it suitable for universal load functions (+page.ts) that run on both server and client.
+ * Unlike the server-only or client-only versions, this doesn't include reactive state management
+ * or navigation features, focusing on pure URL generation and parameter handling.
+ * 
+ * @template Config - The route configuration type extending UniversalRouteConfig
+ * @param options - Configuration options for the universal skRoutes system
+ * @param options.errorURL - URL to redirect to when validation fails (receives error as query param)
+ * @param options.config - Route configuration object mapping addresses to validation functions
+ * 
+ * @returns Object containing urlGenerator and universalPageInfo functions
+ * 
+ * @example
+ * ```typescript
+ * // In a +page.ts file (universal load function)
+ * import { skRoutesUniversal } from '$lib/skRoutes-universal';
+ * 
+ * const { urlGenerator, universalPageInfo } = skRoutesUniversal({
+ *   errorURL: '/error',
+ *   config: {
+ *     '/users/[id]': {
+ *       paramsValidation: z.object({ id: z.string() }).parse,
+ *       searchParamsValidation: z.object({ tab: z.string().optional() }).parse
+ *     }
+ *   }
+ * });
+ * 
+ * export async function load({ params, url, route }) {
+ *   const pageInfo = universalPageInfo('/users/[id]', { params, url, route });
+ *   
+ *   // Access current parameters
+ *   console.log(pageInfo.current.params.id);
+ *   
+ *   // Generate URLs for redirects or links
+ *   const profileUrl = pageInfo.updateParams({
+ *     searchParams: { tab: 'profile' }
+ *   });
+ *   
+ *   return { 
+ *     pageInfo: {
+ *       current: pageInfo.current,
+ *       updateParams: pageInfo.updateParams
+ *     }
+ *   };
+ * }
+ * ```
+ */
+export function skRoutesUniversal<Config extends UniversalRouteConfig>({
+	errorURL,
+	config
+}: {
+	errorURL: string;
+	config: Config;
+}) {
+	/**
+	 * Universal URL generator for configured routes with parameter validation.
+	 * Works in both server and client contexts.
+	 * 
+	 * @param input - URL generation parameters
+	 * @param input.address - Route address pattern (e.g., '/users/[id]')
+	 * @param input.paramsValue - Route parameters object
+	 * @param input.searchParamsValue - Search parameters object
+	 * @returns Object containing the generated URL and validated parameters
+	 */
+	const urlGenerator = createUrlGenerator(config, errorURL);
+
+	/**
+	 * Creates universal route information and parameter update utilities for a specific route.
+	 * 
+	 * This function provides route state access and URL generation utilities that work
+	 * in both server-side and client-side contexts. It's designed for universal load
+	 * functions (+page.ts) that need to run on both server and client without reactive
+	 * state management or navigation features.
+	 * 
+	 * @template Address - The specific route address from the config
+	 * @param routeId - The route address pattern (must match a key in config)
+	 * @param data - Universal page data from SvelteKit
+	 * @param data.params - Current route parameters
+	 * @param data.url - Current URL object with search string
+	 * @param data.route - Current route information
+	 * 
+	 * @returns Object with current state and update function
+	 * 
+	 * @example
+	 * ```typescript
+	 * // In a +page.ts file (universal load function)
+	 * export async function load({ params, url, route }) {
+	 *   const pageInfo = universalPageInfo('/users/[id]', { params, url, route });
+	 *   
+	 *   // Access current parameters
+	 *   const userId = pageInfo.current.params.id;
+	 *   const currentTab = pageInfo.current.searchParams.tab;
+	 *   
+	 *   // Generate new URLs for redirects or links
+	 *   const redirectUrl = pageInfo.updateParams({
+	 *     searchParams: { error: 'not-found' }
+	 *   });
+	 *   
+	 *   // Can be passed to client-side components
+	 *   return { 
+	 *     userId, 
+	 *     currentTab,
+	 *     redirectUrl: redirectUrl.url,
+	 *     pageInfo: {
+	 *       current: pageInfo.current,
+	 *       updateParams: pageInfo.updateParams
+	 *     }
+	 *   };
+	 * }
+	 * ```
+	 */
+	const universalPageInfo = <Address extends keyof Config>(
+		routeId: Address,
+		data: {
+			params: Record<string, string>;
+			url: { search: string };
+			route: { id: string };
+		}
+	) => {
+		const current = urlGenerator({
+			address: routeId,
+			paramsValue: data.params as ParamsType<Config, Address>,
+			searchParamsValue: getUrlParams(data.url.search) as SearchParamsType<Config, Address>
+		});
+
+		/**
+		 * Updates route parameters and returns the new URL without side effects.
+		 * 
+		 * This function generates new URLs with updated parameters. It's suitable for
+		 * both server-side redirects and client-side link generation, but doesn't
+		 * perform any navigation or state updates automatically.
+		 * 
+		 * @param options - Parameter update options
+		 * @param options.params - Partial route parameters to update
+		 * @param options.searchParams - Partial search parameters to update
+		 * @returns Object containing the new URL and validated parameters
+		 */
+		const updateParams = createUpdateParams(
+			routeId as string,
+			data.params,
+			data.url.search,
+			urlGenerator
+		);
+
+		return { 
+			/**
+			 * Current route state containing validated parameters and search parameters.
+			 * These are plain objects (not reactive) suitable for both server and client use.
+			 */
+			current: {
+				params: current.params,
+				searchParams: current.searchParams,
+				url: current.url,
+				error: current.error
+			}, 
+			updateParams 
+		};
+	};
+
+	return { urlGenerator, universalPageInfo };
+}

--- a/src/lib/vite-plugin-skroutes.ts
+++ b/src/lib/vite-plugin-skroutes.ts
@@ -373,10 +373,15 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 			const relativePath = generateRelativeImportPath(schema.filePath);
 
 			if (schema.routeConfig) {
-				// Import the entire route config
-				schemaImports.push(
-					`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
-				);
+				// Only import if the route config has validation functions that will be used
+				const hasUsableValidation = schema.hasParamsValidation || schema.hasSearchParamsValidation;
+				
+				if (hasUsableValidation) {
+					// Import the entire route config
+					schemaImports.push(
+						`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
+					);
+				}
 
 				const paramsValidation = schema.hasParamsValidation
 					? `${schemaAlias}.paramsValidation`
@@ -456,9 +461,8 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 
 		const typeMapping = [...baseTypeMapping, ...serverTypeMapping, ...smartTypeMapping].join(';\n');
 
-		// Check if StandardSchemaV1 is used in the generated content
-		const usesStandardSchema = typeMapping.includes('StandardSchemaV1') || 
-			configEntries.some(entry => entry.includes('StandardSchemaV1'));
+		// Check if StandardSchemaV1 is used in the type mappings (the only place it's actually needed)
+		const usesStandardSchema = typeMapping.includes('StandardSchemaV1');
 
 		const standardSchemaImport = usesStandardSchema ? 'import type { StandardSchemaV1 } from \'skroutes\';' : '';
 
@@ -514,10 +518,15 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 			const relativePath = generateRelativeImportPath(schema.filePath);
 
 			if (schema.routeConfig) {
-				// Import the entire route config
-				schemaImports.push(
-					`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
-				);
+				// Only import if the route config has validation functions that will be used
+				const hasUsableValidation = schema.hasParamsValidation || schema.hasSearchParamsValidation;
+				
+				if (hasUsableValidation) {
+					// Import the entire route config
+					schemaImports.push(
+						`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
+					);
+				}
 
 				const paramsValidation = schema.hasParamsValidation
 					? `${schemaAlias}.paramsValidation`
@@ -597,9 +606,8 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 
 		const typeMapping = [...baseTypeMapping, ...clientTypeMapping, ...smartTypeMapping].join(';\n');
 
-		// Check if StandardSchemaV1 is used in the generated content
-		const usesStandardSchema = typeMapping.includes('StandardSchemaV1') || 
-			configEntries.some(entry => entry.includes('StandardSchemaV1'));
+		// Check if StandardSchemaV1 is used in the type mappings (the only place it's actually needed)
+		const usesStandardSchema = typeMapping.includes('StandardSchemaV1');
 
 		const standardSchemaImport = usesStandardSchema ? 'import type { StandardSchemaV1 } from \'skroutes\';' : '';
 

--- a/src/lib/vite-plugin-skroutes.ts
+++ b/src/lib/vite-plugin-skroutes.ts
@@ -77,6 +77,8 @@ interface PluginOptions {
 
 	/** How to type unconfigured search parameters. @default 'never' */
 	unconfiguredSearchParams?: UnconfiguredSearchParamStrategy;
+	/** Source package name for skRoutes imports in generated files. @default 'skroutes' */
+	skRoutesSource?: string;
 }
 
 /**
@@ -175,7 +177,8 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 		errorURL = '/error',
 		routesDirectory = 'src/routes',
 		unconfiguredParams = 'deriveParams',
-		unconfiguredSearchParams = 'never'
+		unconfiguredSearchParams = 'never',
+		skRoutesSource = 'skroutes'
 	} = options;
 	let root: string;
 
@@ -789,7 +792,7 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 		const usesStandardSchema = typeMapping.includes('StandardSchemaV1');
 
 		const standardSchemaImport = usesStandardSchema
-			? "import type { StandardSchemaV1 } from 'skroutes';"
+			? `import type { StandardSchemaV1 } from '${skRoutesSource}';`
 			: '';
 
 		return `// Auto-generated server-side config by skroutes-plugin
@@ -1119,14 +1122,14 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 		const usesStandardSchema = typeMapping.includes('StandardSchemaV1');
 
 		const standardSchemaImport = usesStandardSchema
-			? "import type { StandardSchemaV1 } from 'skroutes';"
+			? `import type { StandardSchemaV1 } from '${skRoutesSource}';`
 			: '';
 
 		return `// Auto-generated client-side config by skroutes-plugin
 // This file only imports from client-side files and can be safely used in the browser
 ${standardSchemaImport}
 ${detectedImports.join('\n')}
-import type { RouteConfig } from 'skroutes';
+import type { RouteConfig } from '${skRoutesSource}';
 
 // Import schema definitions from client-side page files only
 ${schemaImports.join('\n')}

--- a/src/lib/vite-plugin-skroutes.ts
+++ b/src/lib/vite-plugin-skroutes.ts
@@ -513,12 +513,14 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 					);
 				}
 
+				// Use configured fallback strategies when validators are missing from _routeConfig
+				const smartParams = generateSmartParamValidation(schema.routePath);
 				const paramsValidation = schema.hasParamsValidation
 					? `${schemaAlias}.paramsValidation`
-					: 'undefined';
+					: smartParams.paramsValidation;
 				const searchParamsValidation = schema.hasSearchParamsValidation
 					? `${schemaAlias}.searchParamsValidation`
-					: 'undefined';
+					: smartParams.searchParamsValidation;
 
 				const entry = `'${schema.routePath}': {
           paramsValidation: ${paramsValidation},
@@ -562,13 +564,14 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 				const schemaAlias = `routeConfig${index}`;
 
 				if (schema.routeConfig) {
-					// Use proper type inference with conditional logic
+					// Use proper type inference with conditional logic, respecting configured strategies
+					const smartTypes = generateSmartParamTypes(schema.routePath);
 					const paramsType = schema.hasParamsValidation
 						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>`
-						: 'Record<string, string>';
+						: smartTypes.paramsType;
 					const searchParamsType = schema.hasSearchParamsValidation
 						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>`
-						: 'Record<string, unknown>';
+						: smartTypes.searchParamsType;
 
 					return `  '${schema.routePath}': { params: ${paramsType}; searchParams: ${searchParamsType} }`;
 				}
@@ -658,12 +661,14 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 					);
 				}
 
+				// Use configured fallback strategies when validators are missing from _routeConfig
+				const smartParams = generateSmartParamValidation(schema.routePath);
 				const paramsValidation = schema.hasParamsValidation
 					? `${schemaAlias}.paramsValidation`
-					: 'undefined';
+					: smartParams.paramsValidation;
 				const searchParamsValidation = schema.hasSearchParamsValidation
 					? `${schemaAlias}.searchParamsValidation`
-					: 'undefined';
+					: smartParams.searchParamsValidation;
 
 				const entry = `'${schema.routePath}': {
           paramsValidation: ${paramsValidation},
@@ -707,13 +712,14 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 				const schemaAlias = `routeConfig${index}`;
 
 				if (schema.routeConfig) {
-					// Use proper type inference with conditional logic
+					// Use proper type inference with conditional logic, respecting configured strategies
+					const smartTypes = generateSmartParamTypes(schema.routePath);
 					const paramsType = schema.hasParamsValidation
 						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>`
-						: 'Record<string, string>';
+						: smartTypes.paramsType;
 					const searchParamsType = schema.hasSearchParamsValidation
 						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>`
-						: 'Record<string, unknown>';
+						: smartTypes.searchParamsType;
 
 					return `  '${schema.routePath}': { params: ${paramsType}; searchParams: ${searchParamsType} }`;
 				}

--- a/src/lib/vite-plugin-skroutes.ts
+++ b/src/lib/vite-plugin-skroutes.ts
@@ -232,11 +232,11 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 					`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
 				);
 
-				const paramsValidation = schema.hasParamsValidation 
-					? `${schemaAlias}.paramsValidation` 
+				const paramsValidation = schema.hasParamsValidation
+					? `${schemaAlias}.paramsValidation`
 					: 'undefined';
-				const searchParamsValidation = schema.hasSearchParamsValidation 
-					? `${schemaAlias}.searchParamsValidation` 
+				const searchParamsValidation = schema.hasSearchParamsValidation
+					? `${schemaAlias}.searchParamsValidation`
 					: 'undefined';
 
 				const entry = `'${schema.routePath}': {
@@ -282,11 +282,11 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 
 				if (schema.routeConfig) {
 					// Use proper type inference with conditional logic
-					const paramsType = schema.hasParamsValidation 
-						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>` 
+					const paramsType = schema.hasParamsValidation
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>`
 						: 'Record<string, string>';
-					const searchParamsType = schema.hasSearchParamsValidation 
-						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>` 
+					const searchParamsType = schema.hasSearchParamsValidation
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>`
 						: 'Record<string, unknown>';
 
 					return `  '${schema.routePath}': { params: ${paramsType}; searchParams: ${searchParamsType} }`;
@@ -312,7 +312,7 @@ export function skRoutesPlugin(options: PluginOptions = {}): Plugin {
 
 		return `// Auto-generated server-side config by skroutes-plugin
 // WARNING: This file imports from server files and should only be used server-side
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+export type { StandardSchemaV1 } from 'skroutes';
 ${detectedImports.join('\n')}
 
 // Import schema definitions from both client and server files
@@ -367,11 +367,11 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 					`import { ${schema.routeConfig} as ${schemaAlias} } from '${relativePath}';`
 				);
 
-				const paramsValidation = schema.hasParamsValidation 
-					? `${schemaAlias}.paramsValidation` 
+				const paramsValidation = schema.hasParamsValidation
+					? `${schemaAlias}.paramsValidation`
 					: 'undefined';
-				const searchParamsValidation = schema.hasSearchParamsValidation 
-					? `${schemaAlias}.searchParamsValidation` 
+				const searchParamsValidation = schema.hasSearchParamsValidation
+					? `${schemaAlias}.searchParamsValidation`
 					: 'undefined';
 
 				const entry = `'${schema.routePath}': {
@@ -417,11 +417,11 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 
 				if (schema.routeConfig) {
 					// Use proper type inference with conditional logic
-					const paramsType = schema.hasParamsValidation 
-						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>` 
+					const paramsType = schema.hasParamsValidation
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.paramsValidation>`
 						: 'Record<string, string>';
-					const searchParamsType = schema.hasSearchParamsValidation 
-						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>` 
+					const searchParamsType = schema.hasSearchParamsValidation
+						? `StandardSchemaV1.InferOutput<typeof ${schemaAlias}.searchParamsValidation>`
 						: 'Record<string, unknown>';
 
 					return `  '${schema.routePath}': { params: ${paramsType}; searchParams: ${searchParamsType} }`;
@@ -447,7 +447,7 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 
 		return `// Auto-generated client-side config by skroutes-plugin
 // This file only imports from client-side files and can be safely used in the browser
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+export type { StandardSchemaV1 } from 'skroutes';
 ${detectedImports.join('\n')}
 
 // Import schema definitions from client-side page files only
@@ -503,7 +503,7 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 						// Check if paramsValidation and searchParamsValidation exist as properties in _routeConfig
 						const hasParamsValidation = /paramsValidation\s*:/gm.test(content);
 						const hasSearchParamsValidation = /searchParamsValidation\s*:/gm.test(content);
-						
+
 						schemas.push({
 							routePath,
 							filePath: fullPath,
@@ -548,7 +548,7 @@ export const pluginOptions = ${JSON.stringify({ errorURL }, null, 2)};
 						// Check if paramsValidation and searchParamsValidation exist as properties in _routeConfig
 						const hasParamsValidation = /paramsValidation\s*:/gm.test(content);
 						const hasSearchParamsValidation = /searchParamsValidation\s*:/gm.test(content);
-						
+
 						schemas.push({
 							routePath,
 							filePath: fullPath,

--- a/src/routes/products/[id]/+page.svelte
+++ b/src/routes/products/[id]/+page.svelte
@@ -47,7 +47,7 @@
 		updateParams({ searchParams: { color } });
 	}
 
-	function updateSize(size: string) {
+	function updateSize(size: 'S' | 'M' | 'L' | 'XL') {
 		updateParams({ searchParams: { size } });
 	}
 
@@ -133,9 +133,6 @@
 			<div class="filter-group">
 				<h3>Size</h3>
 				<div class="size-options">
-					<button onclick={() => updateSize('')} class="size-button" class:active={!currentSize}>
-						All Sizes
-					</button>
 					{#each sizes as size}
 						<button
 							onclick={() => updateSize(size)}

--- a/src/routes/test-no-validation/+page.svelte
+++ b/src/routes/test-no-validation/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
+	import { page } from '$app/state';
+	import { pageInfo } from '$lib/auto-skroutes.svelte.js';
+
 	export let data;
+
+	const urlInfo = pageInfo('/test-no-validation', () => page);
 </script>
 
 <h1>Test No Validation Route</h1>
 <p>{data.message}</p>
 <p>This route has an empty _routeConfig with no validation properties.</p>
+<pre>{JSON.stringify(urlInfo.current, null, 2)}</pre>

--- a/src/routes/test-no-validation/+page.ts
+++ b/src/routes/test-no-validation/+page.ts
@@ -1,9 +1,13 @@
+import { universalPageInfo } from '$lib/auto-skroutes-universal';
+
 // Test route with no validation properties at all
 export const _routeConfig = {
 	// Empty config object - no paramsValidation or searchParamsValidation
 };
 
-export const load = () => {
+export const load = (data) => {
+	const { current } = universalPageInfo(data.route.id, data);
+
 	return {
 		message: 'This route has no validation'
 	};

--- a/src/routes/test-no-validation/+page.ts
+++ b/src/routes/test-no-validation/+page.ts
@@ -6,8 +6,6 @@ export const _routeConfig = {
 };
 
 export const load = (data) => {
-	const { current } = universalPageInfo(data.route.id, data);
-
 	return {
 		message: 'This route has no validation'
 	};

--- a/vite.config.example.js
+++ b/vite.config.example.js
@@ -3,7 +3,13 @@ import { defineConfig } from 'vite';
 import { skRoutesPlugin } from 'skroutes/plugin';
 
 export default defineConfig({
-	plugins: [sveltekit(), skRoutesPlugin()],
+	plugins: [
+		sveltekit(),
+		skRoutesPlugin({
+			unconfiguredParams: 'never',
+			unconfiguredSearchParams: 'never'
+		})
+	],
 	define: {
 		// Optional: Define any global constants here
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,9 @@ export default defineConfig({
 		sveltekit(),
 		skRoutesPlugin({
 			imports: [],
-			errorURL: '/error'
+			errorURL: '/error',
 			// Using new defaults: unconfiguredParams: 'deriveParams', unconfiguredSearchParams: 'never'
+			skRoutesSource: '../index.js' // Use relative import during development to avoid circular dependency
 		})
 	],
 	test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
 		sveltekit(),
 		skRoutesPlugin({
 			imports: [],
-			errorURL: '/error'
+			errorURL: '/error',
+			
 		})
 	],
 	test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,8 @@ export default defineConfig({
 		sveltekit(),
 		skRoutesPlugin({
 			imports: [],
-			errorURL: '/error',
-			unconfiguredParams: 'deriveParams',
-			unconfiguredSearchParams: 'never'
+			errorURL: '/error'
+			// Using new defaults: unconfiguredParams: 'deriveParams', unconfiguredSearchParams: 'never'
 		})
 	],
 	test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 		skRoutesPlugin({
 			imports: [],
 			errorURL: '/error',
-			unconfiguredParams: 'never',
+			unconfiguredParams: 'deriveParams',
 			unconfiguredSearchParams: 'never'
 		})
 	],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
 		skRoutesPlugin({
 			imports: [],
 			errorURL: '/error',
-			
+			unconfiguredParams: 'never',
+			unconfiguredSearchParams: 'never'
 		})
 	],
 	test: {


### PR DESCRIPTION
This pull request updates the skroutes configuration and type generation to provide consistent, always-present validation schemas for all routes, even for routes that previously had no validation. It also normalizes the inferred parameter and search parameter types for these routes to empty objects, improving type safety and predictability for both client-side and server-side usage. Additionally, it introduces a new universal route utility and updates internal imports to use the local `skroutes` package.

**Route validation and type normalization:**

- All routes in both `skroutes-client-config.ts` and `skroutes-server-config.ts` now have default validation schemas that return empty objects, ensuring consistent validation even for routes without explicit validation. [[1]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L18-R64) [[2]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L35-R66)
- The inferred types for params and searchParams for routes without validation have been changed from generic records to empty objects (`{}`), making route usage more predictable and type-safe. [[1]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L211-R257) [[2]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L129-R172)
- The validation function for all default schemas now always returns `{ value: {} }` instead of using the input value, further enforcing the empty object type. [[1]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L18-R64) [[2]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L57-R102) [[3]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L89-R124) [[4]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L111-R146) [[5]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L133-R168) [[6]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L155-R190) [[7]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L177-R212) [[8]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L199-R234) [[9]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L55-R105) [[10]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L92-R127) [[11]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L114-R149)

**Internal imports and exports:**

- Updated imports of `StandardSchemaV1` in generated config files to use the local `skroutes` package instead of `@standard-schema/spec`. [[1]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L3-L8) [[2]](diffhunk://#diff-867f5c2f14cf662a9f578238077051220af32cddd54a5d42dfd678007009d691L3-L11)
- Added exports for universal route utilities and types in `index.ts`, and re-exported `StandardSchemaV1` for downstream usage.

**New universal route utility:**

- Introduced `auto-skroutes-universal.ts`, which sets up a universal page info utility using the client route config and a default error URL, simplifying usage in both client and server contexts.

**Versioning:**

- Bumped the package version from `1.1.0` to `1.2.0` in `package.json` to reflect these changes.