### PR TITLE
Fix Client Generation Issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skroutes",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && pnpm run package",

--- a/src/lib/.generated/skroutes-client-config.ts
+++ b/src/lib/.generated/skroutes-client-config.ts
@@ -108,7 +108,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
+          validate: (v: any) => ({ value: v || {} })
         }
       },
         },
@@ -168,7 +168,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
+          validate: (v: any) => ({ value: v || {} })
         }
       },
         },
@@ -190,7 +190,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
+          validate: (v: any) => ({ value: v || {} })
         }
       },
         },
@@ -234,7 +234,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
+          validate: (v: any) => ({ value: v || {} })
         }
       },
         },
@@ -256,7 +256,7 @@ export const clientRouteConfig = {
         '~standard': {
           version: 1,
           vendor: 'skroutes',
-          validate: (v: any) => ({ value: {} })
+          validate: (v: any) => ({ value: v || {} })
         }
       },
         }


### PR DESCRIPTION
This pull request improves the handling of parameter validation in the client configuration and build process, especially for routes that have server-side validation defined. The changes ensure that when server-side validation exists, the client uses a passthrough validation strategy, preserving the server's logic and preventing redundant or conflicting validation on the client.

**Parameter validation improvements:**

* Updated the `validate` function for the `~standard` strategy in multiple places in `skroutes-client-config.ts` to return the provided value or an empty object, ensuring passthrough behavior when no value is given. [[1]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L111-R111) [[2]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L171-R171) [[3]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L193-R193) [[4]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L237-R237) [[5]](diffhunk://#diff-0b8865635b6091108073f0b3164b35b7d4ab6757be24cdbfc8f39b68ba525b41L259-R259)
* Modified the `generateSmartParamValidation` function in `vite-plugin-skroutes.ts` to accept a `hasServerValidation` argument, and to use a passthrough validation strategy for params and searchParams when server-side validation is present. [[1]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fL465-R465) [[2]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fR503-R533)

**Build and configuration enhancements:**

* Updated the plugin logic in `vite-plugin-skroutes.ts` to detect server-side validation for each route and pass this information to `generateSmartParamValidation`, ensuring correct validation strategies are applied during build and for routes missing client config. [[1]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fL919-R948) [[2]](diffhunk://#diff-cd1f81688ae211279d6ebf0043ea36e259291c182ff7222f67bf4c6eba79311fL943-R978)

**Other:**

* Bumped the package version in `package.json` from `1.3.3` to `1.3.4`.